### PR TITLE
Make the clip_box property of GraphicsState opt-in

### DIFF
--- a/celiagg/graphics_state.h
+++ b/celiagg/graphics_state.h
@@ -114,7 +114,7 @@ public:
     };
 
     GraphicsState() :
-        m_clip_box(0, 0, 0, 0),
+        m_clip_box(0.0, 0.0, -1.0, -1.0),  // Invalid by default!
         m_stencil(NULL),
         m_drawing_mode(DrawFillStroke),
         m_text_drawing_mode(TextDrawFill),

--- a/celiagg/ndarray_canvas.h
+++ b/celiagg/ndarray_canvas.h
@@ -180,6 +180,7 @@ private:
     GraphicsState::DrawingMode _convert_text_mode(const GraphicsState::TextDrawingMode tm);
     masked_renderer_t _get_masked_renderer(const GraphicsState& gs);
     inline void _set_aa(const bool& aa);
+    inline void _set_clipping(const GraphicsState::Rect& rect);
 
 private:
     // Target buffer/numpy array must be supplied to constructor.  The following line ensures that no default 

--- a/celiagg/ndarray_canvas.hxx
+++ b/celiagg/ndarray_canvas.hxx
@@ -69,8 +69,7 @@ template<typename pixfmt_t>
 void ndarray_canvas<pixfmt_t>::draw_image(Image& img,
     const agg::trans_affine& transform, const GraphicsState& gs)
 {
-    const GraphicsState::Rect clip = gs.clip_box();
-    m_rasterizer.clip_box(clip.x1, clip.y1, clip.x2, clip.y2);
+    _set_clipping(gs.clip_box());
     // XXX: Apply master alpha here somehow!
 
     if (gs.stencil() == NULL)
@@ -89,8 +88,7 @@ void ndarray_canvas<pixfmt_t>::draw_shape(VertexSource& shape,
     const agg::trans_affine& transform, Paint& linePaint, Paint& fillPaint,
     const GraphicsState& gs)
 {
-    const GraphicsState::Rect clip = gs.clip_box();
-    m_rasterizer.clip_box(clip.x1, clip.y1, clip.x2, clip.y2);
+    _set_clipping(gs.clip_box());
     linePaint.master_alpha(gs.master_alpha());
     fillPaint.master_alpha(gs.master_alpha());
 
@@ -110,8 +108,7 @@ void ndarray_canvas<pixfmt_t>::draw_text(const char* text,
     Font& font, const agg::trans_affine& transform,
     Paint& linePaint, Paint& fillPaint, const GraphicsState& gs)
 {
-    const GraphicsState::Rect clip = gs.clip_box();
-    m_rasterizer.clip_box(clip.x1, clip.y1, clip.x2, clip.y2);
+    _set_clipping(gs.clip_box());
     linePaint.master_alpha(gs.master_alpha());
     fillPaint.master_alpha(gs.master_alpha());
 
@@ -380,5 +377,18 @@ void ndarray_canvas<pixfmt_t>::_set_aa(const bool& aa)
     else
     {
         m_rasterizer.gamma(agg::gamma_threshold(0.5));
+    }
+}
+
+template<typename pixfmt_t>
+void ndarray_canvas<pixfmt_t>::_set_clipping(const GraphicsState::Rect& rect)
+{
+    if (rect.is_valid())
+    {
+        m_rasterizer.clip_box(rect.x1, rect.y1, rect.x2, rect.y2);
+    }
+    else
+    {
+        m_rasterizer.reset_clipping();
     }
 }

--- a/celiagg/tests/test_state.py
+++ b/celiagg/tests/test_state.py
@@ -20,6 +20,9 @@ def test_rect():
     assert r.w == 5.0
     assert r.h == 6.0
 
+    gs = GraphicsState()
+    assert not gs.clip_box.valid
+
 
 def test_state_bad_value_types():
     gs = GraphicsState()

--- a/examples/python_logo.py
+++ b/examples/python_logo.py
@@ -87,8 +87,7 @@ bottom_grad.transform = agg.Transform(0.562541, 0, 0,
                                       0.567972, -9.399749, -5.305317)
 
 canvas = agg.CanvasRGB24(np.zeros((600, 600, 3), dtype=np.uint8))
-gs = agg.GraphicsState(drawing_mode=agg.DrawingMode.DrawFill,
-                       clip_box=agg.Rect(0, 0, 600, 600))
+gs = agg.GraphicsState(drawing_mode=agg.DrawingMode.DrawFill)
 canvas.clear(1, 1, 1)
 transform = agg.Transform()
 transform.translate(300, 300)

--- a/examples/stencil.py
+++ b/examples/stencil.py
@@ -23,8 +23,7 @@ small_box.rect(0, 0, SIZE/2, SIZE/2)
 
 stencil_canvas = agg.CanvasG8(np.zeros((SIZE, SIZE), dtype=np.uint8))
 canvas = agg.CanvasRGB24(np.zeros((SIZE, SIZE, 3), dtype=np.uint8))
-gs = agg.GraphicsState(drawing_mode=agg.DrawingMode.DrawFill, line_width=6.0,
-                       clip_box=agg.Rect(0, 0, SIZE, SIZE))
+gs = agg.GraphicsState(drawing_mode=agg.DrawingMode.DrawFill, line_width=6.0)
 transform = agg.Transform()
 blue_paint = agg.SolidPaint(0.1, 0.1, 1.0)
 white_paint = agg.SolidPaint(1.0, 1.0, 1.0)


### PR DESCRIPTION
Before, a `clip_box` _had_ to be defined for every `GraphicsState` instance, otherwise the entire canvas would be clipped for every drawing call.

This ~is~was pretty annoying behavior, especially for people trying to learn how to use the library. 