### PR TITLE
Don't run twine from within docker

### DIFF
--- a/travis/build-run.sh
+++ b/travis/build-run.sh
@@ -2,3 +2,7 @@
 
 # Run the build-wheels script in the docker container
 docker run --rm -v `pwd`:/io $DOCKER_IMAGE /io/travis/build-wheels.sh
+
+# Upload to PyPI
+pip install twine
+twine upload -u jwiggins wheelhouse/celiagg-*.whl

--- a/travis/build-wheels.sh
+++ b/travis/build-wheels.sh
@@ -28,11 +28,3 @@ for PYBIN in /opt/python/cp{27,35}*/bin/; do
     ${PYBIN}/pip install celiagg --no-index -f /io/wheelhouse
     (cd $HOME; ${PYBIN}/nosetests celiagg)
 done
-
-
-# Upload to PyPI
-PY35BIN=/opt/python/cp35-cp35m/bin
-if [ -n $TRAVIS_TAG ]; then
-    $PY35BIN/pip install twine
-    $PY35BIN/twine upload -u jwiggins /io/wheelhouse/*.whl
-fi


### PR DESCRIPTION
`twine` needs access to `$TWINE_PASSWORD` , which certainly shouldn't be available in the manylinux build container...