### PR TITLE
Conda apparently doesn't have twine. pip install it.

### DIFF
--- a/travis/build-run.sh
+++ b/travis/build-run.sh
@@ -13,8 +13,9 @@ hash -r
 
 conda config --set always_yes yes --set changeps1 no
 conda update -q conda
-conda create -q -n twine_env python=3.5 twine
+conda create -q -n twine_env python=3.5
 source activate twine_env
 
 # Upload to PyPI
+pip install twine
 twine upload -u jwiggins wheelhouse/celiagg-*.whl


### PR DESCRIPTION
This is irritating...