### PR TITLE
Handle the absence of pkg-config better

### DIFF
--- a/celiagg/setup.py
+++ b/celiagg/setup.py
@@ -66,7 +66,7 @@ def get_freetype_info():
         try:
             for key, args in commands.items():
                 data[key] = run_cmd(cmd_prefix + args, env=env)
-        except subprocess.CalledProcessError:
+        except (subprocess.CalledProcessError, OSError):
             pass
         return data
 


### PR DESCRIPTION
Fixes #29 

@corranwebster: This gives the intended behavior. Basically, the user shouldn't see the raw exception traceback, but rather the informative error message.