### PR TITLE
Use bilinear filtering for draw_image w/ non-simple transformation

### DIFF
--- a/celiagg/ndarray_canvas.h
+++ b/celiagg/ndarray_canvas.h
@@ -133,7 +133,7 @@ protected:
 
 private:
 
-    template<typename base_renderer_t>
+    template<typename base_renderer_t, typename span_gen_t>
     void _draw_image_internal(Image& img,
                               const agg::trans_affine& transform,
                               const GraphicsState& gs,
@@ -179,6 +179,7 @@ private:
 
     GraphicsState::DrawingMode _convert_text_mode(const GraphicsState::TextDrawingMode tm);
     masked_renderer_t _get_masked_renderer(const GraphicsState& gs);
+    inline bool _is_simple_transform(const agg::trans_affine& transform);
     inline void _set_aa(const bool& aa);
     inline void _set_clipping(const GraphicsState::Rect& rect);
 


### PR DESCRIPTION
As noted in enthought/enable#247, drawing images with a non-integral offset gives a strange artifact along the edge of the image. This was apparently a consequence of nearest-neighbor sampling.

@corranwebster: This should fix what you were seeing. There is still discoloration at the edges, but it's colored now, instead of the gray "background color" that was showing before. I believe this to be the correct result.