### PR TITLE
Windows Support

### DIFF
--- a/celiagg/setup.py
+++ b/celiagg/setup.py
@@ -127,12 +127,20 @@ def configuration(parent_package='', top_path=None):
     include_dirs = ['agg-svn/agg-2.4/include',
                     'agg-svn/agg-2.4',
                     numpy.get_include()]
-    extra_compile_args = ['-Wfatal-errors', '-Wno-unused-function']
+    if platform.system() == "Windows":
+        # Visual studio does not support these
+        extra_compile_args = []
+    else:
+        extra_compile_args = [
+           '-Wfatal-errors',
+           '-Wno-unused-function'
+        ]
     extra_link_args = []
     define_macros = []
 
     if with_text_rendering:
         if platform.system() == 'Windows':
+            extra_link_args.extend(['Gdi32.lib', 'User32.lib'])
             include_dirs.append('agg-svn/agg-2.4/font_win32_tt')
             font_source = 'agg-svn/agg-2.4/font_win32_tt/agg_font_win32_tt.cpp'
         else:

--- a/celiagg/vertex_source.h
+++ b/celiagg/vertex_source.h
@@ -25,6 +25,7 @@
 #ifndef CELIAGG_VERTEX_SOURCE_H
 #define CELIAGG_VERTEX_SOURCE_H
 
+#define _USE_MATH_DEFINES
 #include <math.h>
 #include <agg_path_storage.h>
 #include <agg_conv_bspline.h>


### PR DESCRIPTION
This is a partial fix for #4. This compiles just fine for python 3.6.

* both -Wfatal-errors and -Wno-unused-function are not compatible with MSVC
* Added Gdi32.lib and User32.lib as extra_link_args
* added a `#define _USE_MATH_DEFINES` since M_PI is not defined in math.h

Tried briefly to compile with Python 2.7, since `stdint.h` is not part of VC 9.0.