### PR TITLE
Use nearest neighbor interpolation

### DIFF
--- a/celiagg/ndarray_canvas.h
+++ b/celiagg/ndarray_canvas.h
@@ -175,7 +175,6 @@ private:
                            base_renderer_t& renderer);
 
     GraphicsState::DrawingMode _convert_text_mode(const GraphicsState::TextDrawingMode tm);
-    inline bool _is_simple_transform(const agg::trans_affine& transform);
     inline void _set_aa(const bool& aa);
     inline void _set_clipping(const GraphicsState::Rect& rect);
 


### PR DESCRIPTION
Fixes #43 (by reverting #32)

I'm going to switch to nearest neighbor interpolation for all image rendering until someone complains about things looking too "chunky". 😄 The check for a rotation or non-integral scale in the transformation matrix was pretty brittle, so it's gone now too.