### PR TITLE
Move CI scripts to Python 3.6, 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,19 +8,15 @@ branches:
 matrix:
   include:
     - os: linux
-      env: BUILD_TYPE="test" PYTHON="2.7" MINICONDA_OS="Linux" BUILD_ARGS=""
-    - os: linux
-      env: BUILD_TYPE="test" PYTHON="3.5" MINICONDA_OS="Linux" BUILD_ARGS=""
-    - os: linux
       env: BUILD_TYPE="test" PYTHON="3.6" MINICONDA_OS="Linux" BUILD_ARGS=""
     - os: linux
-      env: BUILD_TYPE="test" PYTHON="3.5" MINICONDA_OS="Linux" BUILD_ARGS="--install-option --no-text-rendering"
-    - os: osx
-      env: BUILD_TYPE="test" PYTHON="2.7" MINICONDA_OS="MacOSX" BUILD_ARGS=""
-    - os: osx
-      env: BUILD_TYPE="test" PYTHON="3.5" MINICONDA_OS="MacOSX" BUILD_ARGS=""
+      env: BUILD_TYPE="test" PYTHON="3.7" MINICONDA_OS="Linux" BUILD_ARGS=""
+    - os: linux
+      env: BUILD_TYPE="test" PYTHON="3.6" MINICONDA_OS="Linux" BUILD_ARGS="--install-option --no-text-rendering"
     - os: osx
       env: BUILD_TYPE="test" PYTHON="3.6" MINICONDA_OS="MacOSX" BUILD_ARGS=""
+    - os: osx
+      env: BUILD_TYPE="test" PYTHON="3.7" MINICONDA_OS="MacOSX" BUILD_ARGS=""
     - sudo: required
       services:
         - docker

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2014-2015 WUSTL ZPLAB
-Copyright (c) 2016-2017 Celiagg Contributors
+Copyright (c) 2016-2020 Celiagg Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,19 +27,13 @@ environment:
       PYTHON_VERSION: "3.6"
       PYTHON_ARCH: "64"
       CONDA_PY: "36"
-      CONDA_NPY: "112"
+      CONDA_NPY: "117"
 
     - CONDA_ROOT: "C:\\Miniconda3_64"
-      PYTHON_VERSION: "3.5"
+      PYTHON_VERSION: "3.7"
       PYTHON_ARCH: "64"
-      CONDA_PY: "36"
-      CONDA_NPY: "112"
-
-    - CONDA_ROOT: "C:\\Miniconda3_64"
-      PYTHON_VERSION: "2.7"
-      PYTHON_ARCH: "64"
-      CONDA_PY: "27"
-      CONDA_NPY: "110"
+      CONDA_PY: "37"
+      CONDA_NPY: "117"
 
 # We always use a 64-bit machine, but can build x86 distributions
 # with the PYTHON_ARCH variable (which is used by CMD_IN_ENV).

--- a/ci/build-run.sh
+++ b/ci/build-run.sh
@@ -13,7 +13,7 @@ hash -r
 
 conda config --set always_yes yes --set changeps1 no
 conda update -q conda
-conda create -q -n twine_env python=3.5 numpy cython freetype
+conda create -q -n twine_env python=3.6 numpy cython freetype
 source activate twine_env
 
 # Build an SDIST

--- a/ci/build-wheels.sh
+++ b/ci/build-wheels.sh
@@ -26,7 +26,7 @@ for idx in {0..2}; do
 done
 
 # Compile wheels
-for PYBIN in /opt/python/cp{27,35}*/bin; do
+for PYBIN in /opt/python/cp{36,37}*/bin; do
     ${PYBIN}/pip install -r /io/ci/build-requirements.txt
     ${PYBIN}/pip wheel /io/ -w wheelhouse/
 done
@@ -37,7 +37,7 @@ for whl in wheelhouse/*.whl; do
 done
 
 # Install packages and test
-for PYBIN in /opt/python/cp{27,35}*/bin/; do
+for PYBIN in /opt/python/cp{36,37}*/bin/; do
     ${PYBIN}/pip install celiagg --no-index -f /io/wheelhouse
     (cd $HOME; ${PYBIN}/python -m unitest discover -v celiagg)
 done

--- a/ci/install.ps1
+++ b/ci/install.ps1
@@ -84,7 +84,7 @@ function UpdateConda ($python_home) {
 
 
 function main () {
-    InstallMiniconda "3.5" $env:PYTHON_ARCH $env:CONDA_ROOT
+    InstallMiniconda "3.6" $env:PYTHON_ARCH $env:CONDA_ROOT
     UpdateConda $env:CONDA_ROOT
     InstallCondaPackages $env:CONDA_ROOT "conda-build jinja2 anaconda-client"
 }

--- a/ci/run_with_env.cmd
+++ b/ci/run_with_env.cmd
@@ -55,21 +55,16 @@ IF "%CONDA_PY:~2,1%" == "" (
 )
 :: Based on the Python version, determine what SDK version to use, and whether
 :: to set the SDK for 64-bit.
-IF %MAJOR_PYTHON_VERSION% == 2 (
-    SET WINDOWS_SDK_VERSION="v7.0"
-    SET SET_SDK_64=Y
-) ELSE (
-    IF %MAJOR_PYTHON_VERSION% == 3 (
-        SET WINDOWS_SDK_VERSION="v7.1"
-        IF %MINOR_PYTHON_VERSION% LEQ 4 (
-            SET SET_SDK_64=Y
-        ) ELSE (
-            SET SET_SDK_64=N
-        )
+IF %MAJOR_PYTHON_VERSION% == 3 (
+    SET WINDOWS_SDK_VERSION="v7.1"
+    IF %MINOR_PYTHON_VERSION% LEQ 4 (
+        SET SET_SDK_64=Y
     ) ELSE (
-        ECHO Unsupported Python version: "%MAJOR_PYTHON_VERSION%"
-        EXIT /B 1
+        SET SET_SDK_64=N
     )
+) ELSE (
+    ECHO Unsupported Python version: "%MAJOR_PYTHON_VERSION%"
+    EXIT /B 1
 )
 IF "%PYTHON_ARCH%"=="64" (
     IF %SET_SDK_64% == Y (

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,7 +3,7 @@ Welcome to celiagg's documentation!
 
 celiagg is a Cython wrapper of the popular
 `Anti-Grain Geometry library  <http://www.antigrain.com>`_ which
-supports both Python 2 and 3 (2.7, 3.5+).
+supports both Python 3 (3.5+).
 
 Keeping with the tradition of AGG, celiagg aims to have a minimal number of
 dependencies. Currently only `numpy <http://www.numpy.org/>`_ is a required

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 # The MIT License (MIT)
 #
 # Copyright (c) 2014-2016 WUSTL ZPLAB
+# Copyright (c) 2016-2020 Celiagg Contributors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +22,7 @@
 # SOFTWARE.
 #
 # Authors: Erik Hvatum <ice.rikh@gmail.com>
-#          John Wiggins <john.wiggins@xfel.eu>
+#          John Wiggins <jwiggins@enthought.com>
 import os
 import sys
 
@@ -59,7 +60,7 @@ setup(
     configuration=configuration,
     license='MIT',
     version='1.0.4',
-    description='Anti-Grain Geometry for Python (2 & 3) with Cython',
+    description='Anti-Grain Geometry for Python 3 with Cython',
     long_description=long_description,
     url='https://github.com/celiagg/celiagg',
     classifiers=[
@@ -70,7 +71,6 @@ setup(
         'Programming Language :: C++',
         'Programming Language :: Cython',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 3',
         'Topic :: Software Development :: Libraries',
         'Operating System :: Microsoft :: Windows',


### PR DESCRIPTION
This PR marks the end of official Python 2 support for Celiagg.

That _does not_ mean that you won't be able to use Celiagg with Python 2 any longer, only that it's not being tested by the CI infrastructure or provided via wheels on PyPI.