### PR TITLE
Release 1.1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
     name='celiagg',
     configuration=configuration,
     license='MIT',
-    version='1.1.0',
+    version='1.1.1',
     description='Anti-Grain Geometry for Python 3 with Cython',
     long_description=long_description,
     url='https://github.com/celiagg/celiagg',

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
     name='celiagg',
     configuration=configuration,
     license='MIT',
-    version='1.0.4',
+    version='1.1.0',
     description='Anti-Grain Geometry for Python 3 with Cython',
     long_description=long_description,
     url='https://github.com/celiagg/celiagg',


### PR DESCRIPTION
It's been far too long since a release.

PRs since 1.03:
* Use nearest neighbor image interpolation (#61)
* Use stdlib unittest instead of pytest (#64)
* Move CI testing to Pythons 3.6, 3.7 (#66)
* Speed up text rendering (#65)
* Do stroke transformation as late as possible (#67)
* Switch to GitHub Actions for CI (#68, #69)
* Add face_index support to Font (#70)

I think the API addition to `Font` in #70 merits a minor version bump, so there we are.