### PR TITLE
Rework text rendering

### DIFF
--- a/celiagg/__init__.py
+++ b/celiagg/__init__.py
@@ -26,7 +26,7 @@
 
 from . import _celiagg
 from ._celiagg import (
-    AggError, BSpline, BlendMode, DrawingMode, Font, FontCache, FontCacheType,
+    AggError, BSpline, BlendMode, DrawingMode, Font, FontCache,
     GradientSpread, GradientUnits, GraphicsState, Image, InnerJoin,
     LineCap, LineJoin, LinearGradientPaint, Path, PatternPaint, PatternStyle,
     PixelFormat, RadialGradientPaint, Rect, ShapeAtPoints, SolidPaint,
@@ -41,11 +41,10 @@ __all__ = [
     'HAS_TEXT',
 
     'AggError', 'BlendMode', 'BSpline', 'DrawingMode', 'Font', 'FontCache',
-    'FontCacheType', 'GradientSpread', 'GradientUnits', 'GraphicsState',
-    'Image', 'InnerJoin', 'LinearGradientPaint', 'LineCap', 'LineJoin',
-    'RadialGradientPaint', 'Path', 'PatternPaint', 'PatternStyle',
-    'PixelFormat', 'Rect', 'ShapeAtPoints', 'SolidPaint', 'TextDrawingMode',
-    'Transform',
+    'GradientSpread', 'GradientUnits', 'GraphicsState', 'Image', 'InnerJoin',
+    'LinearGradientPaint', 'LineCap', 'LineJoin', 'RadialGradientPaint',
+    'Path', 'PatternPaint', 'PatternStyle', 'PixelFormat', 'Rect',
+    'ShapeAtPoints', 'SolidPaint', 'TextDrawingMode', 'Transform',
 
     'CanvasG8', 'CanvasGA16', 'CanvasRGB24', 'CanvasRGBA32', 'CanvasBGRA32',
     'CanvasRGBA128',

--- a/celiagg/_enums.pxd
+++ b/celiagg/_enums.pxd
@@ -22,10 +22,10 @@
 #
 # Authors: John Wiggins
 
-cdef extern from "font.h" namespace "Font":
-    cdef enum FontCacheType:
-        RasterFontCache
-        VectorFontCache
+cdef extern from "font_cache.h" namespace "FontCache":
+    cdef enum GlyphType:
+        RasterGlyph
+        VectorGlyph
 
 
 cdef extern from "image.h":
@@ -82,6 +82,7 @@ cdef extern from "graphics_state.h" namespace "GraphicsState":
         TextDrawFill
         TextDrawStroke
         TextDrawClip
+        TextDrawRaster
         TextDrawFillStroke
         TextDrawFillClip
         TextDrawStrokeClip

--- a/celiagg/_font.pxd
+++ b/celiagg/_font.pxd
@@ -23,15 +23,12 @@
 # Authors: John Wiggins
 
 from libcpp cimport bool
-cimport _enums
 
 
 cdef extern from "font.h":
     cdef cppclass Font:
-        Font(char* fileName, double height, _enums.FontCacheType ch,
-             unsigned face_index)
+        Font(char* fileName, double height, unsigned face_index)
 
-        _enums.FontCacheType cache_type() const
         unsigned face_index() const
         const char* filepath() const
         bool flip() const

--- a/celiagg/_font_cache.pxd
+++ b/celiagg/_font_cache.pxd
@@ -22,6 +22,7 @@
 #
 # Authors: John Wiggins
 
+cimport _enums
 cimport _font
 cimport _transform
 
@@ -30,5 +31,7 @@ cdef extern from "font_cache.h":
     cdef cppclass FontCache:
         FontCache()
 
+        # NOTE: The GlyphType argument for activate() is ignored here
+        # All text measurement happens with raster glyphs, for speed reasons.
         void activate(_font.Font& font, _transform.trans_affine& transform);
         double measure_width(char* str)

--- a/celiagg/enums.pxi
+++ b/celiagg/enums.pxi
@@ -73,6 +73,7 @@ cpdef enum TextDrawingMode:
     TextDrawFill = _enums.TextDrawFill
     TextDrawStroke = _enums.TextDrawStroke
     TextDrawClip = _enums.TextDrawClip
+    TextDrawRaster = _enums.TextDrawRaster
     TextDrawFillStroke = _enums.TextDrawFillStroke
     TextDrawFillClip = _enums.TextDrawFillClip
     TextDrawStrokeClip = _enums.TextDrawStrokeClip

--- a/celiagg/font.cpp
+++ b/celiagg/font.cpp
@@ -24,20 +24,13 @@
 
 #include "font.h"
 
-Font::Font(char const* fontName, double const height, FontCacheType const ch, unsigned const face_index)
+Font::Font(char const* fontName, double const height, unsigned const face_index)
 : m_height(height)
 , m_font_name(fontName)
-, m_cache_type(ch)
 , m_face_index(face_index)
 , m_flip(false)
 , m_hinting(true)
 {}
-
-Font::FontCacheType
-Font::cache_type() const
-{
-    return m_cache_type;
-}
 
 unsigned
 Font::face_index() const

--- a/celiagg/font.h
+++ b/celiagg/font.h
@@ -31,17 +31,9 @@ class Font
 {
 public:
 
-    enum FontCacheType
-    {
-        RasterFontCache,
-        VectorFontCache
-    };
-
                         Font(char const* fileName, double const height,
-                             FontCacheType const ch = RasterFontCache,
                              unsigned const face_index = 0);
 
-    FontCacheType       cache_type() const;
     unsigned            face_index() const;
     const char*         filepath() const;
 
@@ -58,7 +50,6 @@ private:
 
         double          m_height;
         std::string     m_font_name;
-        FontCacheType   m_cache_type;
         unsigned        m_face_index;
         bool            m_flip;
         bool            m_hinting;

--- a/celiagg/font.pxi
+++ b/celiagg/font.pxi
@@ -23,38 +23,27 @@
 # Authors: John Wiggins
 
 
-cpdef enum FontCacheType:
-    RasterFontCache = _enums.RasterFontCache
-    VectorFontCache = _enums.VectorFontCache 
-
-
 cdef class Font:
-    """Font(path, size, cache_type, face_index=0)
+    """Font(path, size, face_index=0)
 
     :param path: A Unicode string containing the path of a ``Font`` file
     :param size: The size of the font
-    :param cache_type: A ``FontCacheType``
     :param face_index: For .ttc fonts, the index of the desired font within
                         the collection.
     """
     cdef _font.Font* _this
 
-    def __cinit__(self, fontName, double size, FontCacheType ch,
-                    unsigned face_index=0):
+    def __cinit__(self, fontName, double size, unsigned face_index=0):
         fontName = _get_utf8_text(fontName,
                                   "Font path must be a unicode string")
-        self._this = new _font.Font(fontName, size, ch, face_index)
+        self._this = new _font.Font(fontName, size, face_index)
 
     def __dealloc__(self):
         del self._this
 
     def copy(self):
         return Font(self._this.filepath(), self._this.height(),
-                    self._this.cache_type(), self._this.face_index())
-
-    property cache_type:
-        def __get__(self):
-            return FontCacheType(self._this.cache_type())
+                    self._this.face_index())
 
     property face_index:
         def __get__(self):

--- a/celiagg/font_cache.cpp
+++ b/celiagg/font_cache.cpp
@@ -32,7 +32,7 @@
 
 FontCache::FontCache() {}
 FontCache::~FontCache() {}
-void FontCache::activate(const Font&, const agg::trans_affine& transform) {}
+void FontCache::activate(const Font&, const agg::trans_affine& transform, GlyphType const type) {}
 double FontCache::measure_width(char const* str) { return 0.0; }
 
 
@@ -57,12 +57,12 @@ FontCache::~FontCache()
 }
 
 void
-FontCache::activate(const Font& font, const agg::trans_affine& transform)
+FontCache::activate(const Font& font, const agg::trans_affine& transform, GlyphType const type)
 {
 #ifdef _USE_FREETYPE
     m_font_engine.load_font(font.filepath(),
                             font.face_index(),
-                            (font.cache_type() == Font::VectorFontCache) ?
+                            (type == FontCache::VectorGlyph) ?
                                 agg::glyph_ren_outline :
                                 agg::glyph_ren_agg_gray8);
     // Manipulate the aspects of the font which was just loaded.
@@ -78,7 +78,7 @@ FontCache::activate(const Font& font, const agg::trans_affine& transform)
     m_font_engine.hinting(font.hinting());
     m_font_engine.transform(transform);
     m_font_engine.create_font(font.filepath(),
-                             (font.cache_type() == Font::VectorFontCache) ?
+                             (type == FontCache::VectorGlyph) ?
                                 agg::glyph_ren_outline :
                                 agg::glyph_ren_agg_gray8,
                               font.height(),

--- a/celiagg/font_cache.h
+++ b/celiagg/font_cache.h
@@ -45,6 +45,12 @@ class FontCache
 {
 public:
 
+    enum GlyphType
+    {
+        RasterGlyph,
+        VectorGlyph
+    };
+
 #ifdef _ENABLE_TEXT_RENDERING
 #ifdef _USE_FREETYPE
     typedef agg::font_engine_freetype_int32       FontEngine;
@@ -57,7 +63,9 @@ public:
                         FontCache();
                         ~FontCache();
 
-    void                activate(const Font& font, const agg::trans_affine& transform);
+    void                activate(const Font& font,
+                                 const agg::trans_affine& transform,
+                                 GlyphType const type = RasterGlyph);
     double              measure_width(char const* str);
 
 #ifdef _ENABLE_TEXT_RENDERING

--- a/celiagg/font_cache.pxi
+++ b/celiagg/font_cache.pxi
@@ -22,6 +22,7 @@
 #
 # Authors: John Wiggins
 
+
 cdef class FontCache:
     """FontCache()
 

--- a/celiagg/glyph_iter.cpp
+++ b/celiagg/glyph_iter.cpp
@@ -24,11 +24,10 @@
 
 #include "glyph_iter.h"
 
-GlyphIterator::GlyphIterator(char const* utf8Text, FontCache& cache, const bool drawing,
-                             const double x_off, const double y_off)
+GlyphIterator::GlyphIterator(char const* utf8Text, FontCache& cache, const bool drawing)
 : m_font_cache(cache)
-, m_offset_x(x_off)
-, m_offset_y(y_off)
+, m_offset_x(0.0)
+, m_offset_y(0.0)
 , m_text(utf8Text)
 , m_index(0)
 , m_is_drawing(drawing)

--- a/celiagg/glyph_iter.h
+++ b/celiagg/glyph_iter.h
@@ -41,10 +41,9 @@ public:
 
 public:
                         GlyphIterator(char const* utf8Text, FontCache& cache,
-                                      const bool drawing = false,
-                                      const double x_off = 0.0,
-                                      const double y_off = 0.0);
+                                      const bool drawing = false);
 
+    void                offset(double x, double y) { m_offset_x = x; m_offset_y = y; }
     StepAction          step();
     double              x_offset() const { return m_offset_x; }
     double              y_offset() const { return m_offset_y; }

--- a/celiagg/graphics_state.h
+++ b/celiagg/graphics_state.h
@@ -73,11 +73,12 @@ public:
 
     enum TextDrawingMode
     {
-        // Bit 0: fill, Bit 1: stroke, Bit 2: clip
+        // Bit 0: fill, Bit 1: stroke, Bit 2: clip, Bit 3: raster
         TextDrawInvisible = 0x0000,
         TextDrawFill = 0x0001,
         TextDrawStroke = 0x0002,
         TextDrawClip = 0x0004,
+        TextDrawRaster = 0x0008,  // Same as TextDrawFill, but fast and high quality
         TextDrawFillStroke = TextDrawFill | TextDrawStroke,
         TextDrawFillClip = TextDrawFill | TextDrawClip,
         TextDrawStrokeClip = TextDrawStroke | TextDrawClip,
@@ -117,7 +118,7 @@ public:
         m_clip_box(0.0, 0.0, -1.0, -1.0),  // Invalid by default!
         m_stencil(NULL),
         m_drawing_mode(DrawFillStroke),
-        m_text_drawing_mode(TextDrawFill),
+        m_text_drawing_mode(TextDrawRaster),
         m_blend_mode(BlendAlpha),
         m_image_blend_mode(BlendDst),
         m_master_alpha(1.0),

--- a/celiagg/ndarray_canvas.h
+++ b/celiagg/ndarray_canvas.h
@@ -163,13 +163,15 @@ private:
                              base_renderer_t& renderer);
     template<typename base_renderer_t>
     void _draw_text_raster(GlyphIterator& iterator,
-                           agg::trans_affine& transform,
-                           Paint& linePaint, Paint& fillPaint,
+                           Font& font,
+                           const agg::trans_affine& transform,
+                           Paint& fillPaint,
                            const GraphicsState& gs,
                            base_renderer_t& renderer);
     template<typename base_renderer_t>
     void _draw_text_vector(GlyphIterator& iterator,
-                           agg::trans_affine& transform,
+                           Font& font,
+                           const agg::trans_affine& transform,
                            Paint& linePaint, Paint& fillPaint,
                            const GraphicsState& gs,
                            base_renderer_t& renderer);

--- a/celiagg/tests/test_canvas.py
+++ b/celiagg/tests/test_canvas.py
@@ -50,9 +50,7 @@ class TestCanvas(unittest.TestCase):
 
         if agg.HAS_TEXT:
             text = 'Hello!'
-            font = agg.Font(
-                'Times New Roman', 12.0, agg.FontCacheType.RasterFontCache
-            )
+            font = agg.Font('Times New Roman', 12.0)
             with self.assertRaises(TypeError):
                 canvas.draw_text(text, None, transform, gs)
             with self.assertRaises(TypeError):

--- a/celiagg/tests/test_text.py
+++ b/celiagg/tests/test_text.py
@@ -20,18 +20,9 @@ class TestTextDrawing(unittest.TestCase):
         transform = agg.Transform()
 
         text_unicode = 'Hello!'
-        font_unicode = agg.Font(
-            FONT_FILE,
-            12.0,
-            agg.FontCacheType.RasterFontCache,
-            face_index=1,
-        )
+        font_unicode = agg.Font(FONT_FILE, 12.0, face_index=1)
         text_byte = b'Hello!'
-        font_byte = agg.Font(
-            FONT_FILE.encode('utf8'),
-            12.0,
-            agg.FontCacheType.RasterFontCache,
-        )
+        font_byte = agg.Font(FONT_FILE.encode('utf8'), 12.0)
 
         canvas.draw_text(text_unicode, font_unicode, transform, gs)
         canvas.draw_text(text_byte, font_unicode, transform, gs)
@@ -45,7 +36,7 @@ class TestTextDrawing(unittest.TestCase):
         )
         canvas.clear(1.0, 1.0, 1.0)
 
-        font = agg.Font(FONT_FILE, 24.0, agg.FontCacheType.RasterFontCache)
+        font = agg.Font(FONT_FILE, 24.0)
         gs = agg.GraphicsState()
         paint = agg.SolidPaint(1.0, 0.0, 0.0, 1.0)
         transform = agg.Transform()
@@ -65,7 +56,7 @@ class TestTextDrawing(unittest.TestCase):
         canvas = agg.CanvasRGB24(
             np.zeros((100, 100, 3), dtype=np.uint8), font_cache=font_cache,
         )
-        font = agg.Font(FONT_FILE, 12.0, agg.FontCacheType.RasterFontCache)
+        font = agg.Font(FONT_FILE, 12.0)
         gs = agg.GraphicsState()
         paint = agg.SolidPaint(1.0, 0.0, 0.0, 1.0)
         text = 'Some appropriate string'


### PR DESCRIPTION
Hot on the heels of #74, I'm stirring up text rendering yet again.

Namely, I've removed `FontCacheType` entirely. It was something of an implementation detail that had poked its head out and now it's gone. `Font` objects are really just basic descriptions of a font to be loaded when rendering text; they aren't concerned with how they're cached now.

`FontCacheType` was up until now the way to control if text was rendered in raster mode or vector mode. That decision is now captured by the `TextDrawingMode.TextDrawRaster` enumeration value which is also the default value for `GraphicsState.text_drawing_mode`. `TextDrawRaster` is the only text drawing mode which uses the raster rendering path; all other modes use the slower [but much more powerful] vector rendering path.

Another breaking change is that the canvas `draw_text` method now uses the `fill` paint instead of the `stroke` paint when drawing in raster mode. If all of your colored text turns black after this change, that's the reason.