### PR TITLE
Add a draw_shape_at_points method to the canvas

### DIFF
--- a/celiagg/_ndarray_canvas.pxd
+++ b/celiagg/_ndarray_canvas.pxd
@@ -68,6 +68,12 @@ cdef extern from "ndarray_canvas.h":
                         const _transform.trans_affine& transform,
                         _paint.Paint& linePaint, _paint.Paint& fillPaint,
                         const _graphics_state.GraphicsState& gs)
+        void draw_shape_at_points(_vertex_source.VertexSource& shape,
+                                  const double* points,
+                                  const size_t point_count,
+                                  const _transform.trans_affine& transform,
+                                  _paint.Paint& linePaint, _paint.Paint& fillPaint,
+                                  const _graphics_state.GraphicsState& gs)
         void draw_text(const char* text, _font.Font& font,
                        const _transform.trans_affine& transform,
                        _paint.Paint& linePaint, _paint.Paint& fillPaint,

--- a/celiagg/ndarray_canvas.h
+++ b/celiagg/ndarray_canvas.h
@@ -79,6 +79,12 @@ public:
                             const agg::trans_affine& transform,
                             Paint& linePaint, Paint& fillPaint,
                             const GraphicsState& gs) = 0;
+    virtual void draw_shape_at_points(VertexSource& shape,
+                                      const double* points,
+                                      const size_t point_count,
+                                      const agg::trans_affine& transform,
+                                      Paint& linePaint, Paint& fillPaint,
+                                      const GraphicsState& gs) = 0;
     virtual void draw_text(const char* text, Font& font,
                            const agg::trans_affine& transform,
                            Paint& linePaint, Paint& fillPaint,
@@ -108,6 +114,12 @@ public:
                     const agg::trans_affine& transform,
                     Paint& linePaint, Paint& fillPaint,
                     const GraphicsState& gs);
+    void draw_shape_at_points(VertexSource& shape,
+                              const double* points,
+                              const size_t point_count,
+                              const agg::trans_affine& transform,
+                              Paint& linePaint, Paint& fillPaint,
+                              const GraphicsState& gs);
     void draw_text(const char* text, Font& font,
                    const agg::trans_affine& transform,
                    Paint& linePaint, Paint& fillPaint,

--- a/celiagg/ndarray_canvas.hxx
+++ b/celiagg/ndarray_canvas.hxx
@@ -118,6 +118,43 @@ void ndarray_canvas<pixfmt_t>::draw_shape(VertexSource& shape,
 }
 
 template<typename pixfmt_t>
+void ndarray_canvas<pixfmt_t>::draw_shape_at_points(VertexSource& shape,
+    const double* points, const size_t point_count,
+    const agg::trans_affine& transform, Paint& linePaint, Paint& fillPaint,
+    const GraphicsState& gs)
+{
+    agg::simple_polygon_vertex_source _points(points, point_count, false, false);
+    agg::trans_affine pt_trans;
+    unsigned cmd;
+
+    _set_clipping(gs.clip_box());
+    linePaint.master_alpha(gs.master_alpha());
+    fillPaint.master_alpha(gs.master_alpha());
+
+    if (gs.stencil() == NULL)
+    {
+        for (;;)
+        {
+            cmd = _points.vertex(&pt_trans.tx, &pt_trans.ty);
+            if (cmd == agg::path_cmd_end_poly) break;
+
+            _draw_shape_internal(shape, pt_trans * transform, linePaint, fillPaint, gs, m_renderer);
+        }
+    }
+    else
+    {
+        _WITH_MASKED_RENDERER(gs, renderer)
+        for (;;)
+        {
+            cmd = _points.vertex(&pt_trans.tx, &pt_trans.ty);
+            if (cmd == agg::path_cmd_end_poly) break;
+
+            _draw_shape_internal(shape, pt_trans * transform, linePaint, fillPaint, gs, renderer);
+        }
+    }
+}
+
+template<typename pixfmt_t>
 void ndarray_canvas<pixfmt_t>::draw_text(const char* text,
     Font& font, const agg::trans_affine& transform,
     Paint& linePaint, Paint& fillPaint, const GraphicsState& gs)

--- a/celiagg/tests/test_drawing.py
+++ b/celiagg/tests/test_drawing.py
@@ -132,3 +132,19 @@ class TestDrawing(unittest.TestCase):
             path, self.transform, self.state, stroke=self.paint
         )
         assert_equal(expected, self.canvas.array)
+
+    def test_draw_shape_at_points(self):
+        path = agg.Path()
+        path.ellipse(0, 0, 0.5, 0.5)
+        points = [(0.0, 0.0), (0.0, 5.0), (5.0, 0.0), (5.0, 5.0), (2.5, 2.5)]
+        expected = [
+            [1, 0, 0, 0, 1],
+            [0, 0, 0, 0, 0],
+            [0, 0, 1, 0, 0],
+            [0, 0, 0, 0, 0],
+            [1, 0, 0, 0, 1],
+        ]
+        self.canvas.draw_shape_at_points(
+            path, points, self.transform, self.state, stroke=self.paint
+        )
+        assert_equal(expected, self.canvas.array)


### PR DESCRIPTION
Closes #35

This is a proper "`draw_path_at_points`" in the style of [`kiva`](https://docs.enthought.com/enable/kiva.html), but named `draw_shape_at_points` because that's how we do it here... I'm leaving `ShapeAtPoints` in place, because for draws that aren't mixing stroking and filling it's still the faster option.