### PR TITLE
Remember the face index passed to load_font

### DIFF
--- a/agg-svn/agg-2.4/font_freetype/agg_font_freetype.cpp
+++ b/agg-svn/agg-2.4/font_freetype/agg_font_freetype.cpp
@@ -489,7 +489,7 @@ namespace agg
 
 
 
-
+    static const unsigned _face_lookup_scratch_length = 1024;
 
 
 
@@ -505,6 +505,7 @@ namespace agg
         delete [] m_face_names;
         delete [] m_faces;
         delete [] m_signature;
+        delete [] m_face_lookup_scratch_space;
         if(m_library_initialized) FT_Done_FreeType(m_library);
     }
 
@@ -517,9 +518,9 @@ namespace agg
         m_last_error(0),
         m_name(0),
         m_name_len(256-16-1),
-        m_face_index(0),
         m_char_map(FT_ENCODING_NONE),
         m_signature(new char [256+256-16]),
+        m_face_lookup_scratch_space(new char [_face_lookup_scratch_length]),
         m_height(0),
         m_width(0),
         m_hinting(true),
@@ -567,12 +568,17 @@ namespace agg
 
 
     //------------------------------------------------------------------------
-    int font_engine_freetype_base::find_face(const char* face_name) const
+    int font_engine_freetype_base::find_face(const char* face_name, unsigned face_index) const
     {
         unsigned i;
+
+        // Build the lookup string by combining the face_index and face_name
+        snprintf(m_face_lookup_scratch_space, _face_lookup_scratch_length,
+                 "%04u%s", face_index, face_name);
+
         for(i = 0; i < m_num_faces; ++i)
         {
-            if(strcmp(face_name, m_face_names[i]) == 0) return i;
+            if(strcmp(m_face_lookup_scratch_space, m_face_names[i]) == 0) return i;
         }
         return -1;
     }
@@ -612,7 +618,7 @@ namespace agg
         {
             m_last_error = 0;
 
-            int idx = find_face(font_name);
+            int idx = find_face(font_name, face_index);
             if(idx >= 0)
             {
                 m_cur_face = m_faces[idx];
@@ -651,8 +657,8 @@ namespace agg
 
                 if(m_last_error == 0)
                 {
-                    m_face_names[m_num_faces] = new char [strlen(font_name) + 1];
-                    strcpy(m_face_names[m_num_faces], font_name);
+                    m_face_names[m_num_faces] = new char [strlen(font_name) + 4 + 1];
+                    sprintf(m_face_names[m_num_faces], "%04u%s", face_index, font_name);
                     m_cur_face = m_faces[m_num_faces];
                     m_name     = m_face_names[m_num_faces];
                     ++m_num_faces;
@@ -838,10 +844,9 @@ namespace agg
             }
 
             sprintf(m_signature, 
-                    "%s,%u,%d,%d,%d:%dx%d,%d,%d,%08X", 
+                    "%s,%u,%d,%d:%dx%d,%d,%d,%08X",
                     m_name,
                     m_char_map,
-                    m_face_index,
                     int(m_glyph_rendering),
                     m_resolution,
                     m_height,

--- a/agg-svn/agg-2.4/font_freetype/agg_font_freetype.h
+++ b/agg-svn/agg-2.4/font_freetype/agg_font_freetype.h
@@ -109,16 +109,16 @@ namespace agg
 
         void update_char_size();
         void update_signature();
-        int  find_face(const char* face_name) const;
+        int  find_face(const char* face_name, unsigned face_index) const;
 
         bool            m_flag32;
         int             m_change_stamp;
         int             m_last_error;
         char*           m_name;
         unsigned        m_name_len;
-        unsigned        m_face_index;
         FT_Encoding     m_char_map;
         char*           m_signature;
+        char*           m_face_lookup_scratch_space;
         unsigned        m_height;
         unsigned        m_width;
         bool            m_hinting;


### PR DESCRIPTION
This fixes a bug encountered when using TrueType font collections. Basically, the signature for two different fonts from the same collection would be equal. So now, we explicitly add the face index to the face name and use the face name + index when checking for previously loaded faces.