### PR TITLE
Divide Font descriptions into FreeType and Win32.

### DIFF
--- a/celiagg/__init__.py
+++ b/celiagg/__init__.py
@@ -23,14 +23,15 @@
 #
 # Authors: Erik Hvatum <ice.rikh@gmail.com>
 #          John Wiggins
+import sys
 
 from . import _celiagg
 from ._celiagg import (
-    AggError, BSpline, BlendMode, DrawingMode, Font, FontCache,
-    GradientSpread, GradientUnits, GraphicsState, Image, InnerJoin,
-    LineCap, LineJoin, LinearGradientPaint, Path, PatternPaint, PatternStyle,
-    PixelFormat, RadialGradientPaint, Rect, ShapeAtPoints, SolidPaint,
-    TextDrawingMode, Transform,
+    AggError, BSpline, BlendMode, DrawingMode, FontCache, FontWeight,
+    FreeTypeFont, GradientSpread, GradientUnits, GraphicsState, Image,
+    InnerJoin, LineCap, LineJoin, LinearGradientPaint, Path, PatternPaint,
+    PatternStyle, PixelFormat, RadialGradientPaint, Rect, ShapeAtPoints,
+    SolidPaint, TextDrawingMode, Transform, Win32Font,
 )
 
 # Query the library
@@ -43,6 +44,12 @@ def example_font():
     """
     import pkg_resources
 
+    # Windows GDI font selection uses names and not file paths.
+    # Our included font could be added to the system fonts using
+    # `AddFontResourceEx`, but that's beyond the scope of this function.
+    if sys.platform in ('win32', 'cygwin'):
+        return 'Segoe UI'
+
     return pkg_resources.resource_filename(
         'celiagg', 'data/Montserrat-Regular.ttf'
     )
@@ -53,14 +60,21 @@ __all__ = [
     'HAS_TEXT', 'example_font',
 
     'AggError', 'BlendMode', 'BSpline', 'DrawingMode', 'Font', 'FontCache',
-    'GradientSpread', 'GradientUnits', 'GraphicsState', 'Image', 'InnerJoin',
-    'LinearGradientPaint', 'LineCap', 'LineJoin', 'RadialGradientPaint',
-    'Path', 'PatternPaint', 'PatternStyle', 'PixelFormat', 'Rect',
-    'ShapeAtPoints', 'SolidPaint', 'TextDrawingMode', 'Transform',
+    'FontWeight', 'FreeTypeFont', 'GradientSpread', 'GradientUnits',
+    'GraphicsState', 'Image', 'InnerJoin', 'LinearGradientPaint', 'LineCap',
+    'LineJoin', 'RadialGradientPaint', 'Path', 'PatternPaint', 'PatternStyle',
+    'PixelFormat', 'Rect', 'ShapeAtPoints', 'SolidPaint', 'TextDrawingMode',
+    'Transform', 'Win32Font',
 
     'CanvasG8', 'CanvasGA16', 'CanvasRGB24', 'CanvasRGBA32', 'CanvasBGRA32',
     'CanvasRGBA128',
 ]
+
+# Select the correct font class for the platform
+if sys.platform in ('win32', 'cygwin'):
+    Font = Win32Font
+else:
+    Font = FreeTypeFont
 
 # Keep a font cache for callers that don't want to mess with it
 __global_font_cache = None

--- a/celiagg/_enums.pxd
+++ b/celiagg/_enums.pxd
@@ -23,10 +23,24 @@
 #
 # Authors: John Wiggins
 
+cdef extern from "font.h" namespace "Font":
+    cdef enum FontWeight:
+        k_FontWeightAny
+        k_FontWeightThin
+        k_FontWeightExtraLight
+        k_FontWeightLight
+        k_FontWeightRegular
+        k_FontWeightMedium
+        k_FontWeightSemiBold
+        k_FontWeightBold
+        k_FontWeightExtraBold
+        k_FontWeightHeavy
+
+
 cdef extern from "font_cache.h" namespace "FontCache":
     cdef enum GlyphType:
-        RasterGlyph
-        VectorGlyph
+        k_GlyphTypeRaster
+        k_GlyphTypeVector
 
 
 cdef extern from "image.h":

--- a/celiagg/_font.pxd
+++ b/celiagg/_font.pxd
@@ -24,17 +24,22 @@
 # Authors: John Wiggins
 
 from libcpp cimport bool
+cimport _enums
 
 
 cdef extern from "font.h":
     cdef cppclass Font:
-        Font(char* fileName, double height, unsigned face_index)
+        Font(char* fileName, double height, unsigned face_index, _enums.FontWeight weight, bool italic)
 
         unsigned face_index() const
-        const char* filepath() const
+        const char* face_or_path() const
         bool flip() const
         void flip(bool flip)
         double height() const
         void height(double height)
         bool hinting() const
         void hinting(bool hint)
+        bool italic() const
+        void italic(bool italic)
+        _enums.FontWeight weight() const
+        void weight(_enums.FontWeight weight)

--- a/celiagg/enums.pxi
+++ b/celiagg/enums.pxi
@@ -106,3 +106,15 @@ cpdef enum BlendMode:
     BlendSoftLight = _enums.BlendSoftLight
     BlendDifference = _enums.BlendDifference
     BlendExclusion = _enums.BlendExclusion
+
+cpdef enum FontWeight:
+    Any = _enums.k_FontWeightAny
+    Thin = _enums.k_FontWeightThin
+    ExtraLight = _enums.k_FontWeightExtraLight
+    Light = _enums.k_FontWeightLight
+    Regular = _enums.k_FontWeightRegular
+    Medium = _enums.k_FontWeightMedium
+    SemiBold = _enums.k_FontWeightSemiBold
+    Bold = _enums.k_FontWeightBold
+    ExtraBold = _enums.k_FontWeightExtraBold
+    Heavy = _enums.k_FontWeightHeavy

--- a/celiagg/font.cpp
+++ b/celiagg/font.cpp
@@ -25,12 +25,16 @@
 
 #include "font.h"
 
-Font::Font(char const* fontName, double const height, unsigned const face_index)
-: m_height(height)
-, m_font_name(fontName)
+Font::Font(char const* face_or_path, double const height,
+           unsigned const face_index, Font::FontWeight const weight,
+           bool const italic)
+: m_face_or_path(face_or_path)
+, m_height(height)
+, m_weight(weight)
 , m_face_index(face_index)
 , m_flip(false)
 , m_hinting(true)
+, m_italic(italic)
 {}
 
 unsigned
@@ -40,9 +44,9 @@ Font::face_index() const
 }
 
 const char*
-Font::filepath() const
+Font::face_or_path() const
 {
-    return m_font_name.c_str();
+    return m_face_or_path.c_str();
 }
 
 bool
@@ -79,4 +83,28 @@ void
 Font::hinting(bool const hint)
 {
     m_hinting = hint;
+}
+
+bool
+Font::italic() const
+{
+    return m_italic;
+}
+
+void
+Font::italic(bool const italic)
+{
+    m_italic = italic;
+}
+
+Font::FontWeight
+Font::weight() const
+{
+    return m_weight;
+}
+
+void
+Font::weight(Font::FontWeight const weight)
+{
+    m_weight = weight;
 }

--- a/celiagg/font.h
+++ b/celiagg/font.h
@@ -31,29 +31,54 @@
 class Font
 {
 public:
+    // These map directly to the weights used by the WinGDI CreateFont function
+    enum FontWeight {
+        k_FontWeightAny = 0,
+        k_FontWeightThin = 100,
+        k_FontWeightExtraLight = 200,
+        k_FontWeightLight = 300,
+        k_FontWeightRegular = 400,
+        k_FontWeightMedium = 500,
+        k_FontWeightSemiBold = 600,
+        k_FontWeightBold = 700,
+        k_FontWeightExtraBold = 800,
+        k_FontWeightHeavy = 900,
+    };
 
-                        Font(char const* fileName, double const height,
-                             unsigned const face_index = 0);
+public:
 
-    unsigned            face_index() const;
-    const char*         filepath() const;
+                    Font(char const* face_or_path, double const height,
+                         unsigned const face_index = 0,
+                         FontWeight const weight = k_FontWeightRegular,
+                         bool const italic = false);
 
-    bool                flip() const;
-    void                flip(bool const flip);
+    unsigned        face_index() const;
+    const char*     face_or_path() const;
 
-    double              height() const;
-    void                height(double const height);
+    bool            flip() const;
+    void            flip(bool const flip);
 
-    bool                hinting() const;
-    void                hinting(bool const hint);
+    double          height() const;
+    void            height(double const height);
+
+    bool            hinting() const;
+    void            hinting(bool const hint);
+
+    bool            italic() const;
+    void            italic(bool const italic);
+
+    FontWeight      weight() const;
+    void            weight(FontWeight const weight);
 
 private:
 
-        double          m_height;
-        std::string     m_font_name;
-        unsigned        m_face_index;
-        bool            m_flip;
-        bool            m_hinting;
+    std::string     m_face_or_path;
+    double          m_height;
+    FontWeight      m_weight;
+    unsigned        m_face_index;
+    bool            m_flip;
+    bool            m_hinting;
+    bool            m_italic;
 };
 
 #endif // CELIAGG_FONT_H

--- a/celiagg/font_cache.cpp
+++ b/celiagg/font_cache.cpp
@@ -25,8 +25,6 @@
 #include "font_cache.h"
 #include "glyph_iter.h"
 
-#define WIN32_FONT_WEIGHT 400
-
 #ifndef _ENABLE_TEXT_RENDERING
 // This is what happens when you disable font support!
 
@@ -60,9 +58,9 @@ void
 FontCache::activate(const Font& font, const agg::trans_affine& transform, GlyphType const type)
 {
 #ifdef _USE_FREETYPE
-    m_font_engine.load_font(font.filepath(),
+    m_font_engine.load_font(font.face_or_path(),
                             font.face_index(),
-                            (type == FontCache::VectorGlyph) ?
+                            (type == FontCache::k_GlyphTypeVector) ?
                                 agg::glyph_ren_outline :
                                 agg::glyph_ren_agg_gray8);
     // Manipulate the aspects of the font which was just loaded.
@@ -77,14 +75,14 @@ FontCache::activate(const Font& font, const agg::trans_affine& transform, GlyphT
     m_font_engine.flip_y(font.flip());
     m_font_engine.hinting(font.hinting());
     m_font_engine.transform(transform);
-    m_font_engine.create_font(font.filepath(),
-                             (type == FontCache::VectorGlyph) ?
+    m_font_engine.create_font(font.face_or_path(),
+                             (type == FontCache::k_GlyphTypeVector) ?
                                 agg::glyph_ren_outline :
                                 agg::glyph_ren_agg_gray8,
                               font.height(),
                               0.0,
-                              WIN32_FONT_WEIGHT,
-                              false);
+                              font.weight(),
+                              font.italic());
 #endif
 }
 

--- a/celiagg/font_cache.h
+++ b/celiagg/font_cache.h
@@ -47,8 +47,8 @@ public:
 
     enum GlyphType
     {
-        RasterGlyph,
-        VectorGlyph
+        k_GlyphTypeRaster,
+        k_GlyphTypeVector
     };
 
 #ifdef _ENABLE_TEXT_RENDERING
@@ -65,7 +65,7 @@ public:
 
     void                activate(const Font& font,
                                  const agg::trans_affine& transform,
-                                 GlyphType const type = RasterGlyph);
+                                 GlyphType const type = k_GlyphTypeRaster);
     double              measure_width(char const* str);
 
 #ifdef _ENABLE_TEXT_RENDERING

--- a/celiagg/font_cache.pxi
+++ b/celiagg/font_cache.pxi
@@ -36,18 +36,18 @@ cdef class FontCache:
     def __dealloc__(self):
         del self._this
 
-    def width(self, Font font, text):
+    def width(self, FontBase font, text):
         """width(font, text)
         Measures the width of a string rendered with ``font``.
 
         :param font: a ``Font`` instance
         :param text: a unicode string
         """
-        if not isinstance(font, Font):
+        if not isinstance(font, FontBase):
             raise TypeError("font must be a Font instance")
 
         cdef:
-            Font fnt = <Font>font
+            FontBase fnt = <FontBase>font
 
         text = _get_utf8_text(text, "Argument must be a unicode string")
 

--- a/celiagg/ndarray_canvas.hxx
+++ b/celiagg/ndarray_canvas.hxx
@@ -349,7 +349,7 @@ void ndarray_canvas<pixfmt_t>::_draw_text_raster(GlyphIterator& iterator,
     double transform_array[6];
     transform.store_to(transform_array);
     transform_array[4] = 0.0; transform_array[5] = 0.0;
-    m_font_cache.activate(font, agg::trans_affine(transform_array), FontCache::RasterGlyph);
+    m_font_cache.activate(font, agg::trans_affine(transform_array), FontCache::k_GlyphTypeRaster);
 
     // Determine the starting glyph position from the transform and initialize
     // the iterator.
@@ -385,7 +385,7 @@ void ndarray_canvas<pixfmt_t>::_draw_text_vector(GlyphIterator& iterator,
 
     // Activate the font with an identity transform. The passed in transform
     // will be applied later when drawing the generated path.
-    m_font_cache.activate(font, agg::trans_affine(), FontCache::VectorGlyph);
+    m_font_cache.activate(font, agg::trans_affine(), FontCache::k_GlyphTypeVector);
 
     GlyphIterator::StepAction action = GlyphIterator::k_StepActionInvalid;
     while (action != GlyphIterator::k_StepActionEnd)

--- a/celiagg/ndarray_canvas.pxi
+++ b/celiagg/ndarray_canvas.pxi
@@ -271,7 +271,7 @@ cdef class CanvasBase:
                    "reinstall the library.")
             raise RuntimeError(msg)
 
-        if not isinstance(font, Font):
+        if not isinstance(font, FontBase):
             raise TypeError("font must be a Font instance")
         if not isinstance(transform, Transform):
             raise TypeError("transform must be a Transform instance")
@@ -283,7 +283,7 @@ cdef class CanvasBase:
             raise TypeError("fill must be a Paint instance")
 
         cdef:
-            Font fnt = <Font>font
+            FontBase fnt = <FontBase>font
             GraphicsState gs = <GraphicsState>state
             Transform trans = <Transform>transform
             PixelFormat fmt = self.pixel_format

--- a/celiagg/tests/test_font.py
+++ b/celiagg/tests/test_font.py
@@ -1,0 +1,61 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2021 Celiagg Contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# Authors: John Wiggins
+import sys
+import unittest
+
+import celiagg as agg
+
+is_windows = sys.platform in ('win32', 'cygwin')
+
+
+class TestFont(unittest.TestCase):
+    @unittest.skipIf(is_windows, "Don't test FreeTypeFont on Windows")
+    def test_freetype_font(self):
+        path = agg.example_font()
+
+        # Test default arguments
+        font = agg.Font(path, 12.0)
+        self.assertEqual(font.filepath, path)
+        self.assertEqual(font.height, 12.0)
+        self.assertEqual(font.face_index, 0)
+
+        # Then optional
+        font = agg.Font(path, 12.0, face_index=42)
+        self.assertEqual(font.face_index, 42)
+
+    @unittest.skipIf(not is_windows, "Don't test Win32Font on other platforms")
+    def test_win32_font(self):
+        face_name = agg.example_font()
+
+        # Test default arguments
+        font = agg.Font(face_name, 12.0)
+        self.assertEqual(font.face_name, face_name)
+        self.assertEqual(font.height, 12.0)
+        self.assertEqual(font.weight, agg.FontWeight.Regular)
+        self.assertFalse(font.italic)
+
+        # Then optional
+        font = agg.Font(face_name, 12.0, agg.FontWeight.ExtraBold, True)
+        self.assertEqual(font.weight, agg.FontWeight.ExtraBold)
+        self.assertTrue(font.italic)

--- a/celiagg/tests/test_text.py
+++ b/celiagg/tests/test_text.py
@@ -36,7 +36,7 @@ class TestTextDrawing(unittest.TestCase):
         transform = agg.Transform()
 
         text_unicode = 'Hello!'
-        font_unicode = agg.Font(agg.example_font(), 12.0, face_index=1)
+        font_unicode = agg.Font(agg.example_font(), 12.0)
         text_byte = b'Hello!'
         font_byte = agg.Font(agg.example_font().encode('utf8'), 12.0)
 


### PR DESCRIPTION
Fixes #83

The `Font` class is still available and won't break existing code, but now the code is more explicit about what a `Font` object describes.