### PR TITLE
Support face names of arbitrary length in find_face

### DIFF
--- a/agg-svn/agg-2.4/font_freetype/agg_font_freetype.cpp
+++ b/agg-svn/agg-2.4/font_freetype/agg_font_freetype.cpp
@@ -489,7 +489,6 @@ namespace agg
 
 
 
-    static const unsigned _face_lookup_scratch_length = 1024;
 
 
 
@@ -505,7 +504,7 @@ namespace agg
         delete [] m_face_names;
         delete [] m_faces;
         delete [] m_signature;
-        delete [] m_face_lookup_scratch_space;
+        delete [] m_face_lookup_scratch;
         if(m_library_initialized) FT_Done_FreeType(m_library);
     }
 
@@ -520,7 +519,8 @@ namespace agg
         m_name_len(256-16-1),
         m_char_map(FT_ENCODING_NONE),
         m_signature(new char [256+256-16]),
-        m_face_lookup_scratch_space(new char [_face_lookup_scratch_length]),
+        m_face_lookup_scratch_len(512),
+        m_face_lookup_scratch(new char [m_face_lookup_scratch_len]),
         m_height(0),
         m_width(0),
         m_hinting(true),
@@ -568,17 +568,25 @@ namespace agg
 
 
     //------------------------------------------------------------------------
-    int font_engine_freetype_base::find_face(const char* face_name, unsigned face_index) const
+    int font_engine_freetype_base::find_face(const char* face_name, const size_t face_name_len, unsigned face_index)
     {
         unsigned i;
+        size_t const scratch_len = face_name_len + 4 + 1;
+
+        if (scratch_len > m_face_lookup_scratch_len)
+        {
+            delete [] m_face_lookup_scratch;
+            m_face_lookup_scratch_len = scratch_len;
+            m_face_lookup_scratch = new char [m_face_lookup_scratch_len];
+        }
 
         // Build the lookup string by combining the face_index and face_name
-        snprintf(m_face_lookup_scratch_space, _face_lookup_scratch_length,
+        snprintf(m_face_lookup_scratch, m_face_lookup_scratch_len,
                  "%04u%s", face_index, face_name);
 
         for(i = 0; i < m_num_faces; ++i)
         {
-            if(strcmp(m_face_lookup_scratch_space, m_face_names[i]) == 0) return i;
+            if(strcmp(m_face_lookup_scratch, m_face_names[i]) == 0) return i;
         }
         return -1;
     }
@@ -618,7 +626,8 @@ namespace agg
         {
             m_last_error = 0;
 
-            int idx = find_face(font_name, face_index);
+            size_t const font_name_len = strlen(font_name);
+            int idx = find_face(font_name, font_name_len, face_index);
             if(idx >= 0)
             {
                 m_cur_face = m_faces[idx];
@@ -657,7 +666,7 @@ namespace agg
 
                 if(m_last_error == 0)
                 {
-                    m_face_names[m_num_faces] = new char [strlen(font_name) + 4 + 1];
+                    m_face_names[m_num_faces] = new char [font_name_len + 4 + 1];
                     sprintf(m_face_names[m_num_faces], "%04u%s", face_index, font_name);
                     m_cur_face = m_faces[m_num_faces];
                     m_name     = m_face_names[m_num_faces];

--- a/agg-svn/agg-2.4/font_freetype/agg_font_freetype.h
+++ b/agg-svn/agg-2.4/font_freetype/agg_font_freetype.h
@@ -109,7 +109,7 @@ namespace agg
 
         void update_char_size();
         void update_signature();
-        int  find_face(const char* face_name, unsigned face_index) const;
+        int  find_face(const char* face_name, const size_t face_name_len, unsigned face_index);
 
         bool            m_flag32;
         int             m_change_stamp;
@@ -118,7 +118,8 @@ namespace agg
         unsigned        m_name_len;
         FT_Encoding     m_char_map;
         char*           m_signature;
-        char*           m_face_lookup_scratch_space;
+        size_t          m_face_lookup_scratch_len;
+        char*           m_face_lookup_scratch;
         unsigned        m_height;
         unsigned        m_width;
         bool            m_hinting;


### PR DESCRIPTION
This was done when making similar changes in enable. (see https://github.com/enthought/enable/pull/605#pullrequestreview-605347680)