### PR TITLE
Clean up some compiler warnings in AGG

### DIFF
--- a/agg-svn/agg-2.4/font_freetype/agg_font_freetype.cpp
+++ b/agg-svn/agg-2.4/font_freetype/agg_font_freetype.cpp
@@ -422,12 +422,12 @@ namespace agg
             y += bitmap.rows;
             pitch = -pitch;
         }
-        for(i = 0; i < bitmap.rows; i++)
+        for(i = 0; i < (int)bitmap.rows; i++)
         {
             sl.reset_spans();
             bitset_iterator bits(buf, 0);
             int j;
-            for(j = 0; j < bitmap.width; j++)
+            for(j = 0; j < (int)bitmap.width; j++)
             {
                 if(bits.bit()) sl.add_cell(x + j, cover_full);
                 ++bits;
@@ -463,11 +463,11 @@ namespace agg
             y += bitmap.rows;
             pitch = -pitch;
         }
-        for(i = 0; i < bitmap.rows; i++)
+        for(i = 0; i < (int)bitmap.rows; i++)
         {
             sl.reset_spans();
             const int8u* p = buf;
-            for(j = 0; j < bitmap.width; j++)
+            for(j = 0; j < (int)bitmap.width; j++)
             {
                 if(*p) sl.add_cell(x + j, ras.apply_gamma(*p));
                 ++p;

--- a/agg-svn/agg-2.4/include/agg_basics.h
+++ b/agg-svn/agg-2.4/include/agg_basics.h
@@ -228,7 +228,7 @@ namespace agg
     {
         AGG_INLINE static unsigned mul(unsigned a, unsigned b)
         {
-            register unsigned q = a * b + (1 << (Shift-1));
+            unsigned q = a * b + (1 << (Shift-1));
             return (q + (q >> Shift)) >> Shift;
         }
     };

--- a/agg-svn/agg-2.4/include/agg_image_accessors.h
+++ b/agg-svn/agg-2.4/include/agg_image_accessors.h
@@ -174,8 +174,8 @@ namespace agg
     private:
         AGG_INLINE const int8u* pixel() const
         {
-            register int x = m_x;
-            register int y = m_y;
+            int x = m_x;
+            int y = m_y;
             if(x < 0) x = 0;
             if(y < 0) y = 0;
             if(x >= (int)m_pixf->width())  x = m_pixf->width() - 1;

--- a/agg-svn/agg-2.4/include/agg_trans_affine.h
+++ b/agg-svn/agg-2.4/include/agg_trans_affine.h
@@ -292,7 +292,7 @@ namespace agg
     //------------------------------------------------------------------------
     inline void trans_affine::transform(double* x, double* y) const
     {
-        register double tmp = *x;
+        double tmp = *x;
         *x = tmp * sx  + *y * shx + tx;
         *y = tmp * shy + *y * sy  + ty;
     }
@@ -300,7 +300,7 @@ namespace agg
     //------------------------------------------------------------------------
     inline void trans_affine::transform_2x2(double* x, double* y) const
     {
-        register double tmp = *x;
+        double tmp = *x;
         *x = tmp * sx  + *y * shx;
         *y = tmp * shy + *y * sy;
     }
@@ -308,9 +308,9 @@ namespace agg
     //------------------------------------------------------------------------
     inline void trans_affine::inverse_transform(double* x, double* y) const
     {
-        register double d = determinant_reciprocal();
-        register double a = (*x - tx) * d;
-        register double b = (*y - ty) * d;
+        double d = determinant_reciprocal();
+        double a = (*x - tx) * d;
+        double b = (*y - ty) * d;
         *x = a * sy - b * shx;
         *y = b * sx - a * shy;
     }

--- a/agg-svn/agg-2.4/src/agg_trans_double_path.cpp
+++ b/agg-svn/agg-2.4/src/agg_trans_double_path.cpp
@@ -21,10 +21,10 @@ namespace agg
 
     //------------------------------------------------------------------------
     trans_double_path::trans_double_path() :
-        m_kindex1(0.0),
-        m_kindex2(0.0),
         m_base_length(0.0),
         m_base_height(1.0),
+        m_kindex1(0.0),
+        m_kindex2(0.0),
         m_status1(initial),
         m_status2(initial),
         m_preserve_x_scale(true)


### PR DESCRIPTION
* Removed `register` storage class specifiers since they're deprecated in C++17
* Reordered the initializer list of `agg::trans_double_path` to match the class' declaration order
* Added some `(int)` casts to comparisons between signed and unsigned values in the FreeType code