### PR TITLE
Return text cursor position after drawing

### DIFF
--- a/celiagg/_canvas.pxd
+++ b/celiagg/_canvas.pxd
@@ -58,7 +58,8 @@ cdef extern from "canvas_impl.h":
         void draw_text(const char* text, _font.Font& font,
                        const _transform.trans_affine& transform,
                        _paint.Paint& linePaint, _paint.Paint& fillPaint,
-                       const _graphics_state.GraphicsState& gs)
+                       const _graphics_state.GraphicsState& gs,
+                       double* cursorX, double* cursorY)
 
     # Factory functions
     cdef canvas_base* canvas_rgba128(unsigned char* buf, const unsigned width, const unsigned height, const int stride, _font_cache.FontCache& cache, const bool bottom_up);

--- a/celiagg/canvas.h
+++ b/celiagg/canvas.h
@@ -89,7 +89,8 @@ public:
     void draw_text(const char* text, Font& font,
                    const agg::trans_affine& transform,
                    Paint& linePaint, Paint& fillPaint,
-                   const GraphicsState& gs);
+                   const GraphicsState& gs,
+                   double* cursorX, double* cursorY);
 
 protected:
 
@@ -142,7 +143,8 @@ private:
                              const agg::trans_affine& transform,
                              Paint& linePaint, Paint& fillPaint,
                              const GraphicsState& gs,
-                             base_renderer_t& renderer);
+                             base_renderer_t& renderer,
+                             double* cursorX, double* cursorY);
     template<typename base_renderer_t>
     void _draw_text_raster(const char* text,
                            Font& font,

--- a/celiagg/canvas.hxx
+++ b/celiagg/canvas.hxx
@@ -154,7 +154,8 @@ void canvas<pixfmt_t>::draw_shape_at_points(VertexSource& shape,
 template<typename pixfmt_t>
 void canvas<pixfmt_t>::draw_text(const char* text,
     Font& font, const agg::trans_affine& transform,
-    Paint& linePaint, Paint& fillPaint, const GraphicsState& gs)
+    Paint& linePaint, Paint& fillPaint, const GraphicsState& gs,
+    double* cursorX, double* cursorY)
 {
     _set_clipping(gs.clip_box());
     linePaint.master_alpha(gs.master_alpha());
@@ -162,12 +163,12 @@ void canvas<pixfmt_t>::draw_text(const char* text,
 
     if (gs.stencil() == NULL)
     {
-        _draw_text_internal(text, font, transform, linePaint, fillPaint, gs, m_renderer);
+        _draw_text_internal(text, font, transform, linePaint, fillPaint, gs, m_renderer, cursorX, cursorY);
     }
     else
     {
         _WITH_MASKED_RENDERER(gs, renderer)
-        _draw_text_internal(text, font, transform, linePaint, fillPaint, gs, renderer);
+        _draw_text_internal(text, font, transform, linePaint, fillPaint, gs, renderer, cursorX, cursorY);
     }
 }
 

--- a/celiagg/canvas.pxi
+++ b/celiagg/canvas.pxi
@@ -258,6 +258,7 @@ cdef class CanvasBase:
         :param state: A ``GraphicsState`` object
         :param stroke: The ``Paint`` to use for outlines. Defaults to black.
         :param fill: The ``Paint`` to use for fills. Defaults to black.
+        :returns: The text cursor XY position as a tuple
         """
         if not _text_support._has_text_rendering():
             msg = ("The celiagg library was compiled without font support!  "
@@ -283,6 +284,7 @@ cdef class CanvasBase:
             PixelFormat fmt = self.pixel_format
             Paint stroke_paint
             Paint fill_paint
+            double cursor_x, cursor_y
 
         self._check_stencil(gs)
         stroke_paint = self._get_native_paint(stroke, fmt)
@@ -293,7 +295,10 @@ cdef class CanvasBase:
                              dereference(trans._this),
                              dereference(stroke_paint._this),
                              dereference(fill_paint._this),
-                             dereference(gs._this))
+                             dereference(gs._this),
+                             &cursor_x, &cursor_y)
+
+        return (cursor_x, cursor_y)
 
     cdef _check_stencil(self, GraphicsState state):
         """Internal. Checks if a stencil's dimensions match those of the

--- a/celiagg/canvas_impl.h
+++ b/celiagg/canvas_impl.h
@@ -89,7 +89,8 @@ public:
     virtual void draw_text(const char* text, Font& font,
                            const agg::trans_affine& transform,
                            Paint& linePaint, Paint& fillPaint,
-                           const GraphicsState& gs) = 0;
+                           const GraphicsState& gs,
+                           double* cursorX, double* cursorY) = 0;
 };
 
 #endif // CELIAGG_CANVAS_IMPL_H

--- a/celiagg/canvas_text.hxx
+++ b/celiagg/canvas_text.hxx
@@ -28,7 +28,8 @@ template<typename pixfmt_t>
 template<typename base_renderer_t>
 void canvas<pixfmt_t>::_draw_text_internal(const char* text, Font& font,
     const agg::trans_affine& transform, Paint& linePaint, Paint& fillPaint,
-    const GraphicsState& gs, base_renderer_t& renderer)
+    const GraphicsState& gs, base_renderer_t& renderer,
+    double* cursorX, double* cursorY)
 {
     // Flip the font?
     const bool font_flip = font.flip();
@@ -49,6 +50,15 @@ void canvas<pixfmt_t>::_draw_text_internal(const char* text, Font& font,
 
     // Restore the font's flip state to whatever it was
     font.flip(font_flip);
+
+#ifdef _ENABLE_TEXT_RENDERING
+    // Return the text cursor position
+    *cursorX = m_font_cache.shaper().cursor_x();
+    *cursorY = m_font_cache.shaper().cursor_y();
+#else
+    *cursorX = 0.0;
+    *cursorY = 0.0;
+#endif
 }
 
 template<typename pixfmt_t>

--- a/celiagg/tests/test_text.py
+++ b/celiagg/tests/test_text.py
@@ -56,10 +56,18 @@ class TestTextDrawing(unittest.TestCase):
         gs = agg.GraphicsState()
         paint = agg.SolidPaint(1.0, 0.0, 0.0, 1.0)
         transform = agg.Transform()
-        transform.translate(25, 50)
 
         text = 'Hello!'
-        canvas.draw_text(text, font, transform, gs, stroke=paint, fill=paint)
+        width = font_cache.width(font, text)
+        draw_x, draw_y = 25.0, 50.0
+        transform.translate(draw_x, draw_y)
+        cursor = canvas.draw_text(
+            text, font, transform, gs, stroke=paint, fill=paint
+        )
+        self.assertIsNotNone(cursor)
+        # Text cursor Y is unchanged, X is `width` pixels away from `draw_x`
+        self.assertAlmostEqual(cursor[0] - width, draw_x)
+        self.assertEqual(cursor[1], draw_y)
 
         check = np.sum(canvas.array == [255, 0, 0], axis=2) == 3
         self.assertTrue(check.any())


### PR DESCRIPTION
In order drawing of text in chunks, `draw_text` should report back where the text cursor ended up.

Why would anybody want to draw text in chunks? In order to not absorb the task of font fallback handling in the case of rendering text with glyphs not present in the selected font. We'd prefer to let the code which calls `draw_text` to be in charge of those details, so we have to give a bit more feedback.