### PR TITLE
Add a minimal pyproject.toml

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -8,7 +8,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest]
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     runs-on: ${{ matrix.os }}
@@ -20,15 +20,17 @@ jobs:
           sudo apt-get update
           sudo apt-get install libharfbuzz-dev libfreetype-dev
       if: matrix.os == 'ubuntu-latest'
+    - name: Install dependencies for Linux
+      run: |
+          brew install pkg-config freetype harfbuzz
+      if: matrix.os == 'macos-latest'
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: python -m pip install cython numpy
     - name: Install library (w/ text rendering support)
       run: python -m pip install -e .
-      if: matrix.os == 'ubuntu-latest'
+      if: matrix.os != 'windows-latest'
     - name: Install library (w/o text rendering support)
       run: python -m pip install -e . --install-option --no-text-rendering
       if: matrix.os != 'ubuntu-latest'

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -33,6 +33,6 @@ jobs:
       if: matrix.os != 'windows-latest'
     - name: Install library (w/o text rendering support)
       run: python -m pip install -e . --install-option --no-text-rendering
-      if: matrix.os != 'ubuntu-latest'
+      if: matrix.os == 'windows-latest'
     - name: Run tests
       run: python -m unittest discover -v celiagg

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -8,7 +8,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     runs-on: ${{ matrix.os }}
@@ -28,11 +28,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install library (w/ text rendering support)
+    - name: Install library and dependencies
       run: python -m pip install -e .
-      if: matrix.os != 'windows-latest'
-    - name: Install library (w/o text rendering support)
-      run: python -m pip install -e . --install-option --no-text-rendering
-      if: matrix.os == 'windows-latest'
     - name: Run tests
       run: python -m unittest discover -v celiagg

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -20,7 +20,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install libharfbuzz-dev libfreetype-dev
       if: matrix.os == 'ubuntu-latest'
-    - name: Install dependencies for Linux
+    - name: Install dependencies for MacOS
       run: |
           brew install pkg-config freetype harfbuzz
       if: matrix.os == 'macos-latest'

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -20,15 +20,17 @@ jobs:
           sudo apt-get update
           sudo apt-get install libharfbuzz-dev libfreetype-dev
       if: matrix.os == 'ubuntu-latest'
-    - name: Install dependencies for MacOS
-      run: |
-          brew install pkg-config freetype harfbuzz
-      if: matrix.os == 'macos-latest'
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install library and dependencies
       run: python -m pip install -e .
+      if: matrix.os == 'ubuntu-latest'
+    - name: Install library and dependencies (no text rendering)
+      run: python -m pip install -e .
+      env:
+      - CELIAGG_NO_TEXT_RENDERING: 1
+      if: matrix.os != 'ubuntu-latest'
     - name: Run tests
       run: python -m unittest discover -v celiagg

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Install library and dependencies (no text rendering)
       run: python -m pip install -e .
       env:
-      - CELIAGG_NO_TEXT_RENDERING: 1
+        CELIAGG_NO_TEXT_RENDERING: 1
       if: matrix.os != 'ubuntu-latest'
     - name: Run tests
       run: python -m unittest discover -v celiagg

--- a/README.rst
+++ b/README.rst
@@ -26,6 +26,11 @@ Building from source with the Freetype font library on macOS requires
 the `pkg-config` tool which can be installed via Homebrew, MacPorts, or
 other macOS package management systems.
 
+To build without text support, set the ``CELIAGG_NO_TEXT_RENDERING``
+environment variable while building, eg.
+``CELIAGG_NO_TEXT_RENDERING=1 pip install celiagg``
+
+
 Dependencies
 ------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["cython", "oldest-supported-numpy", "setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ class PatchedSdist(_sdist):
 
 
 def has_text_rendering():
-    return os.environ.get("CELIAGG_NO_TEXT_RENDERING", None) is not None
+    return os.environ.get("CELIAGG_NO_TEXT_RENDERING", None)
 
 
 def has_pkgconfig():
@@ -108,19 +108,15 @@ def run_pkgconfig(name, exit_on_fail=True):
 
     if len(data) < 2:
         msg = ("Failed to execute pkg-config {name}. If {name} is "
-               "installed in standard system locations, it may work to run "
-               "this script with --no-pkg-config. Otherwise, appropriate "
-               "CFLAGS and LDFLAGS environment variables must be set.\n\n"
+               "installed in standard system locations, this may still work. "
+               "Otherwise, appropriate CFLAGS and LDFLAGS environment "
+               "variables must be set.\n\n"
                "If you wish to disable text rendering, you can re-run this "
                "script with the --no-text-rendering flag.")
         print(msg.format(name=name), file=sys.stderr)
 
-        # NOTE: Avoid exiting when pip is running an egg_info command. Without
-        # this, it's not possible to avoid freetype when installing from pip.
-        if exit_on_fail and 'egg_info' not in sys.argv:
-            exit(-1)
-        else:
-            return [], []
+        # couldn't find flags, so return empty lists
+        return [], []
     return data['cflags'], data['ldflags']
 
 
@@ -181,13 +177,14 @@ def create_extension():
     ]
 
     if has_text_rendering():
+        print(
+            "Text rendering enabled.",
+            file=sys.stderr,
+        )
         if platform.system() == 'Windows':
             extra_link_args.extend(['Gdi32.lib', 'User32.lib'])
             include_dirs.append('agg-svn/agg-2.4/font_win32_tt')
             font_source = 'agg-svn/agg-2.4/font_win32_tt/agg_font_win32_tt.cpp'
-
-            sources.append(font_source)
-            define_macros.append(('_ENABLE_TEXT_RENDERING', None))
 
             # XXX: Figure out how to enable Harfbuzz!
         else:
@@ -211,7 +208,7 @@ def create_extension():
         define_macros.append(('_ENABLE_TEXT_RENDERING', None))
     else:
         print(
-            "Text rendering disabled.\n\n",
+            "Text rendering disabled.",
             file=sys.stderr,
         )
 

--- a/setup.py
+++ b/setup.py
@@ -241,7 +241,7 @@ setup(
         'Operating System :: MacOS',
     ],
     requires=requires,
-    install_requires=requires,
+    install_requires=['numpy'],
     cmdclass=cmdclass,
     ext_modules=[create_extension()],
     packages=['celiagg', 'celiagg.tests'],

--- a/setup.py
+++ b/setup.py
@@ -178,8 +178,8 @@ def create_extension():
         include_dirs.append('agg-svn/agg-2.4/font_freetype')
         font_source = 'agg-svn/agg-2.4/font_freetype/agg_font_freetype.cpp'
 
-        sources.append(font_source)
-        define_macros.append(('_ENABLE_TEXT_RENDERING', None))
+    sources.append(font_source)
+    define_macros.append(('_ENABLE_TEXT_RENDERING', None))
 
     return Extension(
         'celiagg._celiagg',

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ class PatchedSdist(_sdist):
 
 
 def has_text_rendering():
-    return os.environ.get("CELIAGG_NO_TEXT_RENDERING", None)
+    return not os.environ.get("CELIAGG_NO_TEXT_RENDERING", None)
 
 
 def has_pkgconfig():

--- a/setup.py
+++ b/setup.py
@@ -177,10 +177,7 @@ def create_extension():
     ]
 
     if has_text_rendering():
-        print(
-            "Text rendering enabled.",
-            file=sys.stderr,
-        )
+        print("Text rendering enabled.", file=sys.stderr)
         if platform.system() == 'Windows':
             extra_link_args.extend(['Gdi32.lib', 'User32.lib'])
             include_dirs.append('agg-svn/agg-2.4/font_win32_tt')
@@ -207,10 +204,7 @@ def create_extension():
         sources.append(font_source)
         define_macros.append(('_ENABLE_TEXT_RENDERING', None))
     else:
-        print(
-            "Text rendering disabled.",
-            file=sys.stderr,
-        )
+        print("Text rendering disabled.", file=sys.stderr)
 
     return Extension(
         'celiagg._celiagg',

--- a/setup.py
+++ b/setup.py
@@ -241,6 +241,7 @@ setup(
         'Operating System :: MacOS',
     ],
     requires=requires,
+    install_requires=requires,
     cmdclass=cmdclass,
     ext_modules=[create_extension()],
     packages=['celiagg', 'celiagg.tests'],


### PR DESCRIPTION
This is enough to permit installation without needing `numpy` and `cython` in the environment via PEP-517 style isolated builds.

Fixes #105 
