### PR TITLE
Build wheels for more platforms

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -28,9 +28,6 @@ jobs:
       with:
         python-version: '3.11'
 
-    - name: Install Python packages needed for wheel build and upload
-      run: python -m pip install twine
-
     - name: Build wheels
       uses: pypa/cibuildwheel@v2.12.1
 
@@ -47,5 +44,6 @@ jobs:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
+        python -m pip install twine
         python -m twine check --strict wheelhouse/*.whl
         python -m twine upload wheelhouse/*.whl

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -14,23 +14,25 @@ jobs:
     steps:
     - name: Check out the release commit
       uses: actions/checkout@v3
-    - name: Setup EDM
-      uses: enthought/setup-edm-action@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
       with:
-        edm-version: ${{ env.INSTALL_EDM_VERSION }}
-    - name: Install build environment
-      run: |
-        edm --config ci/.edm.yaml install -y --version 3.8 cython numpy
-        edm run -- pip install twine
+        python-version: '3.10'
+
+    - name: Install Python packages needed for sdist build and upload
+      run: python -m pip install build twine
+
     - name: Build sdist
-      run: edm run -- python setup.py sdist
-    - name: Publish sdist to PyPI
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        edm run -- python -m twine check dist/*.tar.gz
-        edm run -- python -m twine upload dist/*.tar.gz
+      run: python -m build --sdist
+
+    # - name: Publish sdist to PyPI
+    #   env:
+    #     TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+    #     TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+    #   run: |
+    #     edm run -- python -m twine check dist/*.tar.gz
+    #     edm run -- python -m twine upload dist/*.tar.gz
 
   build-wheel-linux:
     runs-on: ubuntu-latest
@@ -48,15 +50,62 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: 3.11
     - name: Install Python packages needed for wheel upload
       run: |
         python -m pip install --upgrade pip setuptools
         python -m pip install twine
-    - name: Publish wheels to PyPI
+    # - name: Publish wheels to PyPI
+    #   env:
+    #     TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+    #     TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+    #   run: |
+    #     python -m twine check dist/*-manylinux*.whl
+    #     python -m twine upload dist/*-manylinux*.whl
+
+  build-wheel-all:
+    strategy:
+      matrix:
+        os: [windows-latest, macos-latest, ubuntu-latest]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+
+    - name: Check out the release commit
+      uses: actions/checkout@v3
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+      with:
+        platforms: arm64
+      if: runner.os == 'Linux'
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+
+    - name: Install Python packages needed for wheel build and upload
+      run: python -m pip install twine
+
+    - name: Build wheels
+      uses: pypa/cibuildwheel@v2.9.0
       env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        python -m twine check dist/*-manylinux*.whl
-        python -m twine upload dist/*-manylinux*.whl
+        CIBW_SKIP: "{*-musllinux-*,*_ppc64le,*_s390x,*_i686}"
+
+    - name: Archive build
+      uses: actions/upload-artifact@v3
+      with:
+        name: html-doc-bundle
+        path: docs/build/html
+        # don't need these kept for long
+        retention-days: 7
+
+    # - name: Check and upload wheels
+    #   env:
+    #     TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+    #     TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+    #   run: |
+    #     python -m twine check --strict wheelhouse/*.whl
+    #     python -m twine upload wheelhouse/*.whl

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -3,6 +3,7 @@ name: Publish release to PyPI
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 env:
   INSTALL_EDM_VERSION: 3.3.1

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -5,66 +5,8 @@ on:
     types: [published]
   workflow_dispatch:
 
-env:
-  INSTALL_EDM_VERSION: 3.3.1
-
 jobs:
-  build-sdist:
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Check out the release commit
-      uses: actions/checkout@v3
-
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.10'
-
-    - name: Install Python packages needed for sdist build and upload
-      run: python -m pip install build twine
-
-    - name: Build sdist
-      run: python -m build --sdist
-
-    # - name: Publish sdist to PyPI
-    #   env:
-    #     TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-    #     TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-    #   run: |
-    #     edm run -- python -m twine check dist/*.tar.gz
-    #     edm run -- python -m twine upload dist/*.tar.gz
-
-  build-wheel-linux:
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Check out the release commit
-      uses: actions/checkout@v3
-    - name: Build manylinux Python wheels
-      uses: RalfG/python-wheels-manylinux-build@v0.5.0
-      with:
-        python-versions: 'cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39 cp310-cp310 cp311-cp311'
-        build-requirements: 'cython numpy'
-        system-packages: 'zlib-devel'
-        pre-build-command: 'sh ci/build-wheel-deps.sh'
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.11
-    - name: Install Python packages needed for wheel upload
-      run: |
-        python -m pip install --upgrade pip setuptools
-        python -m pip install twine
-    # - name: Publish wheels to PyPI
-    #   env:
-    #     TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-    #     TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-    #   run: |
-    #     python -m twine check dist/*-manylinux*.whl
-    #     python -m twine upload dist/*-manylinux*.whl
-
-  build-wheel-all:
+  build-and-publish-wheel-all:
     strategy:
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
@@ -72,7 +14,6 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-
     - name: Check out the release commit
       uses: actions/checkout@v3
 
@@ -91,22 +32,20 @@ jobs:
       run: python -m pip install twine
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.9.0
-      env:
-        CIBW_SKIP: "{*-musllinux-*,*_ppc64le,*_s390x,*_i686}"
+      uses: pypa/cibuildwheel@v2.12.1
 
     - name: Archive build
       uses: actions/upload-artifact@v3
       with:
-        name: html-doc-bundle
-        path: docs/build/html
+        name: wheels
+        path: wheelhouse
         # don't need these kept for long
         retention-days: 7
 
-    # - name: Check and upload wheels
-    #   env:
-    #     TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-    #     TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-    #   run: |
-    #     python -m twine check --strict wheelhouse/*.whl
-    #     python -m twine upload wheelhouse/*.whl
+    - name: Check and upload wheels
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        python -m twine check --strict wheelhouse/*.whl
+        python -m twine upload wheelhouse/*.whl

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -31,7 +31,7 @@ jobs:
       run: python -m pip install twine
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.12
+      uses: pypa/cibuildwheel@v2.12.1
       env:
         CIBW_SKIP: "{py36-*,*-musllinux-*,*_ppc64le,*_s390x,*_i686}"
 

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -1,7 +1,6 @@
 name: Build wheels and archive
 
 on:
-- pull_request
 - workflow_dispatch
 
 jobs:

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -4,9 +4,7 @@ on:
 - pull_request
 - workflow_dispatch
 
-env:
-  INSTALL_EDM_VERSION: 3.3.1
-
+jobs:
   build-wheel-all:
     strategy:
       matrix:

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Build wheels
       uses: pypa/cibuildwheel@v2.12.1
       env:
-        CIBW_SKIP: "{py36-*,*-musllinux-*,*_ppc64le,*_s390x,*_i686}"
+        CIBW_ARCHS_LINUX: "auto aarch64"
 
     - name: Archive build
       uses: actions/upload-artifact@v3

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -1,8 +1,8 @@
 name: Build wheels and archive
 
 on:
-- workflow_dispatch:
-- pull_request:
+- pull_request
+- workflow_dispatch
 
 env:
   INSTALL_EDM_VERSION: 3.3.1

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -32,16 +32,12 @@ jobs:
 
     - name: Build wheels
       uses: pypa/cibuildwheel@v2.12.1
-      env:
-        CIBW_ARCHS_LINUX: "auto aarch64"
-        CIBW_BEFORE_ALL_LINUX: ci/build-wheel-deps.sh
-        CIBW_SKIP: pp*
 
     - name: Archive build
       uses: actions/upload-artifact@v3
       with:
-        name: html-doc-bundle
-        path: docs/build/html
+        name: wheels-{{ matrix.os }}
+        path: wheelhouse
         # don't need these kept for long
         retention-days: 7
 

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -34,7 +34,8 @@ jobs:
       uses: pypa/cibuildwheel@v2.12.1
       env:
         CIBW_ARCHS_LINUX: "auto aarch64"
-        CIBW_BEFORE_BUILD_LINUX: ci/build-wheel-deps.sh
+        CIBW_BEFORE_ALL_LINUX: ci/build-wheel-deps.sh
+        CIBW_SKIP: pp*
 
     - name: Archive build
       uses: actions/upload-artifact@v3

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -34,6 +34,7 @@ jobs:
       uses: pypa/cibuildwheel@v2.12.1
       env:
         CIBW_ARCHS_LINUX: "auto aarch64"
+        CIBW_BEFORE_BUILD_LINUX: ci/build-wheel-deps.sh
 
     - name: Archive build
       uses: actions/upload-artifact@v3

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Archive build
       uses: actions/upload-artifact@v3
       with:
-        name: wheels-{{ matrix.os }}
+        name: wheels
         path: wheelhouse
         # don't need these kept for long
         retention-days: 7

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -27,9 +27,6 @@ jobs:
       with:
         python-version: '3.11'
 
-    - name: Install Python packages needed for wheel build and upload
-      run: python -m pip install twine
-
     - name: Build wheels
       uses: pypa/cibuildwheel@v2.12.1
 
@@ -40,11 +37,3 @@ jobs:
         path: wheelhouse
         # don't need these kept for long
         retention-days: 7
-
-    # - name: Check and upload wheels
-    #   env:
-    #     TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-    #     TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-    #   run: |
-    #     python -m twine check --strict wheelhouse/*.whl
-    #     python -m twine upload wheelhouse/*.whl

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -31,9 +31,9 @@ jobs:
       run: python -m pip install twine
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.9.0
+      uses: pypa/cibuildwheel@v2.12
       env:
-        CIBW_SKIP: "{*-musllinux-*,*_ppc64le,*_s390x,*_i686}"
+        CIBW_SKIP: "{py36-*,*-musllinux-*,*_ppc64le,*_s390x,*_i686}"
 
     - name: Archive build
       uses: actions/upload-artifact@v3

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -1,0 +1,55 @@
+name: Build wheels and archive
+
+on:
+- workflow_dispatch:
+- pull_request:
+
+env:
+  INSTALL_EDM_VERSION: 3.3.1
+
+  build-wheel-all:
+    strategy:
+      matrix:
+        os: [windows-latest, macos-latest, ubuntu-latest]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+
+    - name: Check out the release commit
+      uses: actions/checkout@v3
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+      with:
+        platforms: arm64
+      if: runner.os == 'Linux'
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+
+    - name: Install Python packages needed for wheel build and upload
+      run: python -m pip install twine
+
+    - name: Build wheels
+      uses: pypa/cibuildwheel@v2.9.0
+      env:
+        CIBW_SKIP: "{*-musllinux-*,*_ppc64le,*_s390x,*_i686}"
+
+    - name: Archive build
+      uses: actions/upload-artifact@v3
+      with:
+        name: html-doc-bundle
+        path: docs/build/html
+        # don't need these kept for long
+        retention-days: 7
+
+    # - name: Check and upload wheels
+    #   env:
+    #     TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+    #     TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+    #   run: |
+    #     python -m twine check --strict wheelhouse/*.whl
+    #     python -m twine upload wheelhouse/*.whl

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -13,7 +13,6 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-
     - name: Check out the release commit
       uses: actions/checkout@v3
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,14 @@
 [build-system]
 requires = ["cython", "oldest-supported-numpy", "setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.cibuildwheel]
+skip = 'pp*'
+
+[tool.cibuildwheel.macos]
+archs = ['auto', 'universal2']
+
+[tool.cibuildwheel.linux]
+archs = ['auto', 'aarch64']
+before-all = "apt-get install libfreetype-dev libharfbuzz-dev"
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,6 @@ build-backend = "setuptools.build_meta"
 [tool.cibuildwheel]
 skip = 'pp* *-musllinux*'
 
-[tool.cibuildwheel.macos]
-archs = ['auto', 'arm64']
-
 [tool.cibuildwheel.linux]
 archs = ['auto', 'aarch64']
 before-all = "yum install -y freetype-devel harfbuzz-devel"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 skip = 'pp*'
 
 [tool.cibuildwheel.macos]
-archs = ['auto', 'arm64', 'universal2']
+archs = ['auto', 'arm64']
 
 [tool.cibuildwheel.linux]
 archs = ['auto', 'aarch64']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,5 +10,5 @@ archs = ['auto', 'arm64', 'universal2']
 
 [tool.cibuildwheel.linux]
 archs = ['auto', 'aarch64']
-before-all = "yum install libfreetype-devel libharfbuzz-devel"
+before-all = "yum install freetype-devel harfbuzz-devel"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,5 +10,5 @@ archs = ['auto', 'arm64']
 
 [tool.cibuildwheel.linux]
 archs = ['auto', 'aarch64']
-before-all = "yum install freetype-devel harfbuzz-devel"
+before-all = "yum install -y freetype-devel harfbuzz-devel"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["cython", "oldest-supported-numpy", "setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
-skip = 'pp*'
+skip = 'pp* *-musllinux*'
 
 [tool.cibuildwheel.macos]
 archs = ['auto', 'arm64']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,9 +6,9 @@ build-backend = "setuptools.build_meta"
 skip = 'pp*'
 
 [tool.cibuildwheel.macos]
-archs = ['auto', 'universal2']
+archs = ['auto', 'arm64', 'universal2']
 
 [tool.cibuildwheel.linux]
 archs = ['auto', 'aarch64']
-before-all = "apt-get install libfreetype-dev libharfbuzz-dev"
+before-all = "yum install libfreetype-devel libharfbuzz-devel"
 

--- a/setup.py
+++ b/setup.py
@@ -254,4 +254,5 @@ setup(
     package_data={
         'celiagg': ['data/*'],
     },
+    python_requires=">=3.7",
 )


### PR DESCRIPTION
Adds a separate build workflow using CIBuildWheel and then integrates it into the release workflow.

This builds for CPython on Intel Mac, Intel Windows and Intel and ARM Linux (glibc only).

ToDo:

- [x] turn off PR builds