### PR TITLE
FIX: SDIST build failure

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -24,12 +24,12 @@ jobs:
       if: runner.os == 'Linux'
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.12'
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.12.1
+      uses: pypa/cibuildwheel@v2.18.1
 
     - name: Archive build
       uses: actions/upload-artifact@v3
@@ -56,9 +56,9 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.12'
 
     - name: Install Python packages needed for build and upload
       run: |

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -22,12 +22,12 @@ jobs:
       if: runner.os == 'Linux'
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.12'
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.12.1
+      uses: pypa/cibuildwheel@v2.18.1
 
     - name: Archive build
       uses: actions/upload-artifact@v3

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -15,22 +15,27 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+
     - name: Install dependencies for Linux
       run: |
           sudo apt-get update
           sudo apt-get install libharfbuzz-dev libfreetype-dev
       if: matrix.os == 'ubuntu-latest'
+
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Install library and dependencies
       run: python -m pip install -e .
       if: matrix.os == 'ubuntu-latest'
+
     - name: Install library and dependencies (no text rendering)
       run: python -m pip install -e .
       env:
         CELIAGG_NO_TEXT_RENDERING: 1
       if: matrix.os != 'ubuntu-latest'
+
     - name: Run tests
       run: python -m unittest discover -v celiagg

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,6 +5,8 @@ include celiagg/*.pxd
 include celiagg/*.pxi
 include celiagg/*.pyx
 include celiagg/data/*
+include pyproject.toml
+include setup.py
 include LICENSE
 include README.rst
 graft agg-svn/agg-2.4/include

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,10 @@ class PatchedSdist(_sdist):
     def run(self):
         from Cython.Build import cythonize
 
-        cythonize([os.path.join('celiagg', '_celiagg.pyx')])
+        cythonize(
+            [os.path.join('celiagg', '_celiagg.pyx')],
+            include_path=['celiagg'],
+        )
         _sdist.run(self)
 
 


### PR DESCRIPTION
2.1.5 release was blown due to Cython SDIST creation bug. This PR fixes that and bumps some version numbers for the Github actions.