### PR TITLE
Fix build error with FreeType 2.13.3+

### DIFF
--- a/agg-svn/agg-2.4/font_freetype/agg_font_freetype.cpp
+++ b/agg-svn/agg-2.4/font_freetype/agg_font_freetype.cpp
@@ -155,9 +155,9 @@ namespace agg
         FT_Vector   v_start;
         double x1, y1, x2, y2, x3, y3;
 
-        FT_Vector*  point;
-        FT_Vector*  limit;
-        char*       tags;
+        FT_Vector*           point;
+        FT_Vector*           limit;
+        unsigned char*       tags;
 
         int   n;         // index of contour in outline
         int   first;     // index of first point in contour


### PR DESCRIPTION
Fixes build error with clang++ (14.0.0):
```txt
agg-svn/agg-2.4/font_freetype/agg_font_freetype.cpp:181:35: fatal error: assigning to 'char *' from 'unsigned char *' converts between pointers to integer types where one is of the unique plain 'char' type and the other is not
            tags  = outline.tags  + first;
                    ~~~~~~~~~~~~~~^~~~~~~
```