### PR TITLE
FIX: Build error with new FreeType (2.13.3+)

### DIFF
--- a/agg-svn/agg-2.4/font_freetype/agg_font_freetype.cpp
+++ b/agg-svn/agg-2.4/font_freetype/agg_font_freetype.cpp
@@ -155,9 +155,13 @@ namespace agg
         FT_Vector   v_start;
         double x1, y1, x2, y2, x3, y3;
 
-        FT_Vector*  point;
-        FT_Vector*  limit;
-        char*       tags;
+        FT_Vector*      point;
+        FT_Vector*      limit;
+#if (FREETYPE_MAJOR == 2 && FREETYPE_MINOR == 13 && FREETYPE_PATCH >= 3) || (FREETYPE_MAJOR == 2 && FREETYPE_MINOR > 13) || FREETYPE_MAJOR > 2
+        unsigned char*  tags;
+#else
+        char*           tags;
+#endif
 
         int   n;         // index of contour in outline
         int   first;     // index of first point in contour

--- a/agg-svn/agg-2.4/font_freetype/agg_font_freetype2.cpp
+++ b/agg-svn/agg-2.4/font_freetype/agg_font_freetype2.cpp
@@ -155,9 +155,13 @@ namespace fman {
         FT_Vector   v_start;
         double x1, y1, x2, y2, x3, y3;
 
-        FT_Vector*  point;
-        FT_Vector*  limit;
-        char*       tags;
+        FT_Vector*      point;
+        FT_Vector*      limit;
+#if (FREETYPE_MAJOR == 2 && FREETYPE_MINOR == 13 && FREETYPE_PATCH >= 3) || (FREETYPE_MAJOR == 2 && FREETYPE_MINOR > 13) || FREETYPE_MAJOR > 2
+        unsigned char*  tags;
+#else
+        char*           tags;
+#endif
 
         int   n;         // index of contour in outline
         int   first;     // index of first point in contour


### PR DESCRIPTION
This PR adds a check for the freetype version in order to pick a variable type in the font code.

FreeType 2.13.3 changes the type of a field in `FT_Outline`:
https://gitlab.freedesktop.org/freetype/freetype/-/blob/VER-2-13-3/include/freetype/ftimage.h?ref_type=tags#L353

Related merge request:
https://gitlab.freedesktop.org/freetype/freetype/-/merge_requests/330